### PR TITLE
Refactor Memory.slice #2

### DIFF
--- a/src/dafny/test.dfy
+++ b/src/dafny/test.dfy
@@ -5,8 +5,8 @@ import opened EVM
 
 // Check most simple program possible
 method test_01(gas: nat) returns (returndata: seq<u8>)
-//ensures |returndata| > 31
-//ensures Int.read_u8(returndata,31) == 0x7b
+ensures |returndata| == 32
+ensures Int.read_u8(returndata,31) == 0x7b
 {
   // Initialise EVM
   var vm := EVM.create(map[],gas,[PUSH1, 0x7b, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN]);
@@ -28,10 +28,8 @@ method test_01(gas: nat) returns (returndata: seq<u8>)
   assert EVM.peek(vm,1) == 32;
   // RETURN
   var r := EVM.execute(vm);
-  // // Done
-  var data := data(r);
-  assert |data| > 8;
-  return [];
+  // Done
+  return data(r);
 }
 
 /**

--- a/src/dafny/util/memory.dfy
+++ b/src/dafny/util/memory.dfy
@@ -169,18 +169,22 @@ module Memory {
     }
 
     /**
-     * Slice out a section of memory.
+     * Slice out a section of memory.  This is implemented in a subdivision
+     * style as this seems to work better (in terms of theorem prover performance).
      */
     function method slice(mem:T, address:u256, len:nat) : seq<u8>
       requires (address as int + len) <= MAX_UINT256
       decreases len
     {
-      if len == 0 then
+      if len == 0
+      then
         []
-      else if address in mem.contents
+      else if len == 1
         then
-        [mem.contents[address]] + slice(mem,address+1,len-1)
+        [read_u8(mem,address)]
       else
-        [0] + slice(mem,address+1,len-1)
+        var pivot := len / 2;
+        var middle := address + (pivot as u256);
+        slice(mem,address,pivot) + slice(mem,middle, len - pivot)
     }
 }


### PR DESCRIPTION
This refactors Memory.slice to use a subdivision method, rather than an
iterative style.  The theory was that this would reduce work on the
theorem prover.  In fact, that does seem to be the case as I can now
verify my test contract again.

Despite this interesting success, I still think it might be nice to
try reworking Memory to use a seq<u8>.  My feeling is that this will
still offer the best overall performance.