### PR TITLE
Add notes related to additional memory check. #4

### DIFF
--- a/src/dafny/evm.dfy
+++ b/src/dafny/evm.dfy
@@ -358,6 +358,10 @@ module EVM {
     if operands(vm) >= 1
       then
       var loc := peek(vm,0);
+      // NOTE: This condition is not specified in the yellow paper.
+      // Its not clear whether that was intended or not.  However, its
+      // impossible to trigger this in practice (due to the gas costs
+      // involved).
       if (loc as int) + 31 <= MAX_UINT256
         then
         var val := read(vm,loc);
@@ -378,6 +382,10 @@ module EVM {
       then
       var loc := peek(vm,0);
       var val := peek(vm,1);
+      // NOTE: This condition is not specified in the yellow paper.
+      // Its not clear whether that was intended or not.  However, its
+      // impossible to trigger this in practice (due to the gas costs
+      // involved).
       if (loc as int) + 31 <= MAX_UINT256
         then
         // Write big endian order


### PR DESCRIPTION
There are some additional checks in the code which do not correspond to
anything in the Yellow Paper.  This is because the situations in
question cannot arise in practice due to the very high gas costs that
would be required to trigger them.