### PR TITLE
Fix #17

### DIFF
--- a/src/dafny/evm.dfy
+++ b/src/dafny/evm.dfy
@@ -273,10 +273,10 @@ module EVM {
     else if opcode == SGT then evalSGT(vm')
     else if opcode == EQ then evalEQ(vm')
     else if opcode == ISZERO then evalISZERO(vm')
-      // AND
-      // OR
-      // XOR
-      // NOT
+    else if opcode == AND then evalAND(vm')
+    else if opcode == OR then evalOR(vm')
+    else if opcode == XOR then evalXOR(vm')
+    else if opcode == NOT then evalNOT(vm')
       // BYTE
       // SHL
       // SHR
@@ -459,6 +459,61 @@ module EVM {
         Result.OK(push(pop(vm),1))
       else
         Result.OK(push(pop(vm),0))
+    else
+      Result.INVALID
+  }
+
+  /**
+   * Bitwise AND operation.
+   */
+  function method evalAND(vm:T) : Result {
+    if operands(vm) >= 2
+      then
+      var lhs := peek(vm,0) as bv256;
+      var rhs := peek(vm,1) as bv256;
+      var res := (lhs & rhs) as u256;
+      Result.OK(push(pop(pop(vm)),res))
+    else
+      Result.INVALID
+  }
+
+  /**
+   * Bitwise OR operation.
+   */
+  function method {:verify false} evalOR(vm:T) : Result {
+    if operands(vm) >= 2
+      then
+      var lhs := peek(vm,0) as bv256;
+      var rhs := peek(vm,1) as bv256;
+      var res := (lhs | rhs) as u256;
+      Result.OK(push(pop(pop(vm)),res))
+    else
+      Result.INVALID
+  }
+
+  /**
+   * Bitwise XOR operation.
+   */
+  function method {:verify false} evalXOR(vm:T) : Result {
+    if operands(vm) >= 2
+      then
+      var lhs := peek(vm,0) as bv256;
+      var rhs := peek(vm,1) as bv256;
+      var res := (lhs ^ rhs) as u256;
+      Result.OK(push(pop(pop(vm)),res))
+    else
+      Result.INVALID
+  }
+
+  /**
+   * Bitwise NOT operation.
+   */
+  function method evalNOT(vm:T) : Result {
+    if operands(vm) >= 1
+      then
+      var mhs := peek(vm,0) as bv256;
+      var res := (!mhs) as u256;
+      Result.OK(push(pop(vm),res))
     else
       Result.INVALID
   }

--- a/src/test/java/dafnyevm/Tests.java
+++ b/src/test/java/dafnyevm/Tests.java
@@ -145,6 +145,76 @@ public class Tests {
 	}
 
 	// ========================================================================
+	// AND / OR / XOR / NOT
+	// ========================================================================
+
+	@Test
+	public void test_and_01() {
+		// 0b0001 & 0b0001  => 0b0001
+		runExpecting(new int[] { PUSH1, 0b0001, PUSH1, 0b0001, AND, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN }, UINT256(0b0001));
+	}
+
+	@Test
+	public void test_and_02() {
+		// 0b0001 & 0b0011  => 0b0001
+		runExpecting(new int[] { PUSH1, 0b0011, PUSH1, 0b0001, AND, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN }, UINT256(0b0001));
+	}
+
+	@Test
+	public void test_and_03() {
+		// 0b0101 & 0b0011  => 0b0001
+		runExpecting(new int[] { PUSH1, 0b0011, PUSH1, 0b0101, AND, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN }, UINT256(0b0001));
+	}
+
+	@Test
+	public void test_or_01() {
+		// 0b0001 | 0b0001  => 0b0001
+		runExpecting(new int[] { PUSH1, 0b0001, PUSH1, 0b0001, OR, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN }, UINT256(0b0001));
+	}
+
+	@Test
+	public void test_or_02() {
+		// 0b0001 | 0b0011  => 0b0011
+		runExpecting(new int[] { PUSH1, 0b0011, PUSH1, 0b0001, OR, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN }, UINT256(0b0011));
+	}
+
+	@Test
+	public void test_or_03() {
+		// 0b0101 | 0b0011  => 0b0111
+		runExpecting(new int[] { PUSH1, 0b0011, PUSH1, 0b0101, OR, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN }, UINT256(0b0111));
+	}
+
+	@Test
+	public void test_xor_01() {
+		// 0b0001 ^ 0b0001  => 0b0000
+		runExpecting(new int[] { PUSH1, 0b0001, PUSH1, 0b0001, XOR, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN }, UINT256(0b0000));
+	}
+
+	@Test
+	public void test_xor_02() {
+		// 0b0001 ^ 0b0011  => 0b0010
+		runExpecting(new int[] { PUSH1, 0b0011, PUSH1, 0b0001, XOR, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN }, UINT256(0b0010));
+	}
+
+	@Test
+	public void test_xor_03() {
+		// 0b0101 ^ 0b0011  => 0b0110
+		runExpecting(new int[] { PUSH1, 0b0011, PUSH1, 0b0101, XOR, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN }, UINT256(0b0110));
+	}
+
+	@Test
+	public void test_not_01() {
+		// ~0b00000101 => 0b11111010
+		runExpecting(new int[] { PUSH1, 0b0101, NOT, PUSH1, 0x1F, MSTORE8, PUSH1, 0x20, PUSH1, 0x00, RETURN }, UINT256(0b11111010));
+	}
+
+	@Test
+	public void test_not_02() {
+		// ~0b00000101 => 0b11111010
+		runExpecting(new int[] { PUSH1, 0b0101, NOT, PUSH1, 0x0, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN }, not(UINT256(0b00000101)));
+	}
+
+	// ========================================================================
 	// LT / GT / SLT / SGT / EQ / ISZERO
 	// ========================================================================
 
@@ -407,5 +477,13 @@ public class Tests {
 			}
 			return r;
 		}
+	}
+
+	private byte[] not(byte[] bytes) {
+		byte[] r = new byte[bytes.length];
+		for (int i = 0; i < bytes.length; ++i) {
+			r[i] = (byte) ~(bytes[i]);
+		}
+		return r;
 	}
 }


### PR DESCRIPTION
This adds imeplementations for AND/OR/XOR and NOT bytecodes.  These are
implemented by converting to bitvectors.  However, there appear to be
some problems with OR and XOR for reasons unknown.  Specifically, they
cause verification to timeout.  So, both implementations are marked
{:verify false} and a separate issue create to resolve this (see #23).

In addition, a small number of tests have been added to verify correct
operation.