### PR TITLE
Support JUMP/JUMPI/PC

### DIFF
--- a/src/main/java/dafnyevm/Main.java
+++ b/src/main/java/dafnyevm/Main.java
@@ -135,6 +135,15 @@ public class Main {
 		}
 
 		/**
+		 * Indicates exceptional outcome.
+		 *
+		 * @return
+		 */
+		public boolean isInvalid() {
+			return data == null;
+		}
+
+		/**
 		 * Get any return data from this contract call. <code>null</code> indicates
 		 * something went wrong.
 		 *


### PR DESCRIPTION
This adds support for three more bytecodes, along with a small number of
tests.

This also fixes a bug in the EVM.decode() function which was not
returning an INVALID after running over the end of the code sequence.