### PR TITLE
Fix #79

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,6 +93,7 @@ sourceSets {
 // In this section you declare the dependencies for your production and test code
 dependencies {
     implementation("commons-cli:commons-cli:1.5.0")
+    implementation("org.apache.commons:commons-lang3:3.12.0")
     implementation("org.json:org.json:chargebee-1.0")
     implementation files('evm-java/DafnyRuntime.jar')
     //

--- a/src/main/java/dafnyevm/core/StateTest.java
+++ b/src/main/java/dafnyevm/core/StateTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2022 ConsenSys Software Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software dis-
+ * tributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package dafnyevm.core;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+public class StateTest {
+	public enum Expectation {
+		/**
+		 * Indicates test ran to completion, possibly producing output data.
+		 */
+		OK,
+		/**
+		 * Indicates not enough gas to start with!
+		 */
+		IntrinsicGas,
+		/**
+		 * Indicates out-of-gas.
+		 */
+		OutOfGas,
+		/**
+		 * Transaction type not supported (?).
+		 */
+		TypeNotSupported,
+		/**
+		 * Indicates test ran but caused a revert.
+		 */
+		REVERT,
+		/**
+		 * Indicates an outcome was not generated due to some kind of internal issue
+		 * (e.g. fork not supported, transaction type not supported, etc).
+		 */
+		FAILURE
+	}
+
+	public final Map<String, Integer> indexes;
+	public final Expectation expect;
+
+	public StateTest(Map<String, Integer> indices, Expectation expect) {
+		this.indexes = Collections.unmodifiableMap(indices);
+		this.expect = expect;
+	}
+
+	public static StateTest fromJSON(JSONObject json) throws JSONException {
+		JSONObject is = json.getJSONObject("indexes");
+		HashMap<String, Integer> map = new HashMap<>();
+		map.put("data", is.getInt("data"));
+		map.put("gas", is.getInt("gas"));
+		map.put("value", is.getInt("value"));
+		Expectation kind;
+		if (json.has("expectException")) {
+			String except = json.getString("expectException");
+			switch(except) {
+			case "TR_IntrinsicGas": {
+				kind = Expectation.IntrinsicGas;
+				break;
+			}
+			case "TR_GasLimitReached": {
+				kind = Expectation.OutOfGas;
+				break;
+			}
+			case "TR_TypeNotSupported": {
+				kind = Expectation.TypeNotSupported;
+				break;
+			}
+			default:
+				throw new RuntimeException("unrecognised exception: " + except);
+			}
+		} else {
+			kind = Expectation.OK;
+		}
+		return new StateTest(map, kind);
+	}
+
+	public static class Outcome {
+		public final String name;
+		public final String fork;
+		public final boolean pass;
+
+		public Outcome(String name, String fork, boolean pass) {
+			this.name = name;
+			this.fork = fork;
+			this.pass = pass;
+		}
+
+		/**
+		 * Identifies whether this test was actually runnable. If not, then there would
+		 * be no corresponding trace data generated for it. Otherwise, we can expecte
+		 * trace data.
+		 *
+		 * @return
+		 */
+		public boolean wasRunnable() {
+			return pass;
+		}
+
+		public static Outcome fromJSON(JSONObject json) throws JSONException {
+			String name = json.getString("name");
+			boolean pass = json.getBoolean("pass");
+			String fork = json.getString("fork");
+			return new Outcome(name, fork, pass);
+		}
+	}
+}

--- a/src/main/java/dafnyevm/core/Transaction.java
+++ b/src/main/java/dafnyevm/core/Transaction.java
@@ -14,6 +14,7 @@
 package dafnyevm.core;
 
 import java.math.BigInteger;
+import java.util.Map;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -56,65 +57,89 @@ public class Transaction {
 	}
 
 	/**
-	 * Parse transaction information from a JSON input file, as used by state tests
-	 * found in the Ethereum Reference Tests.
+	 * A transaction template is a transaction parameterised on three values:
+	 * <code>data</code>, <code>gasLimit</code> and <code>value</code>. For each of
+	 * these items, a template has a predefined array of values. A transaction can
+	 * then be instantiated from a template by providing a <i>index</i> into the
+	 * array of each item.
 	 *
-	 * @param tx
-	 * @return
+	 * @author David J. Pearce
+	 *
 	 */
-	public static Transaction fromJSON(JSONObject json) throws JSONException {
-		BigInteger to = Hex.toBigInt(json.getString("to"));
-		BigInteger sender = Hex.toBigInt(json.getString("sender"));
-		BigInteger gasPrice;
-		if(json.has("gasPrice")) {
-			gasPrice = Hex.toBigInt(json.getString("gasPrice"));
-		} else {
-			System.out.println("*** MISSING GAS PRICE");
-			gasPrice = BigInteger.ZERO;
+	public static class Template {
+		private final Transaction template;
+		private final BigInteger[] gasLimits;
+		private final BigInteger[] values;
+		private final byte[][] datas;
+
+		public Template(BigInteger sender, BigInteger to, BigInteger[] gasLimits, BigInteger gasPrice, BigInteger nonce,
+				BigInteger[] values, byte[][] datas) {
+			// Create the "templated" transaction which has empty slots for the
+			// parameterised values.
+			this.template = new Transaction(sender,to,null,gasPrice,nonce,null,null);
+			this.gasLimits = gasLimits;
+			this.values = values;
+			this.datas = datas;
 		}
-		BigInteger nonce = Hex.toBigInt(json.getString("nonce"));
-		BigInteger value = parseValueArray(json.getJSONArray("value"));
-		byte[] data = parseDataArray(json.getJSONArray("data"));
-		// FIXME: need to figure out the meaning of the gas limit.
-		return new Transaction(sender, to, null, gasPrice, nonce, value, data);
+
+		/**
+		 * Instantiate a transaction with a given set of _indexes_. That is, indices
+		 * which refer to the array of available values for each item.
+		 *
+		 * @param data
+		 * @param gas
+		 * @param value
+		 * @return
+		 */
+		public Transaction instantiate(Map<String,Integer> indices) {
+			int g = indices.get("gas");
+			int d = indices.get("data");
+			int v = indices.get("value");
+			return new Transaction(template.sender, template.to, gasLimits[g], template.gasPrice, template.nonce,
+					values[v], datas[d]);
+		}
+
+		/**
+		 * Parse transaction template information from a JSON input file, as used by
+		 * state tests found in the Ethereum Reference Tests.
+		 *
+		 * @param tx
+		 * @return
+		 */
+		public static Template fromJSON(JSONObject json) throws JSONException {
+			BigInteger to = Hex.toBigInt(json.getString("to"));
+			BigInteger sender = Hex.toBigInt(json.getString("sender"));
+			BigInteger gasPrice;
+			if (json.has("gasPrice")) {
+				gasPrice = Hex.toBigInt(json.getString("gasPrice"));
+			} else {
+				System.out.println("*** MISSING GAS PRICE");
+				gasPrice = BigInteger.ZERO;
+			}
+			BigInteger nonce = Hex.toBigInt(json.getString("nonce"));
+			BigInteger[] gasLimits = parseValueArray(json.getJSONArray("gasLimit"));
+			BigInteger[] values = parseValueArray(json.getJSONArray("value"));
+			byte[][] datas = parseDataArray(json.getJSONArray("data"));
+			return new Template(sender, to, gasLimits, gasPrice, nonce, values, datas);
+		}
+
 	}
 
 
-	public static byte[] parseDataArray(JSONArray json) throws JSONException {
+	public static byte[][] parseDataArray(JSONArray json) throws JSONException {
 		byte[][] bytes = new byte[json.length()][];
 		for(int i=0;i!=json.length();++i) {
 			bytes[i] = Hex.toBytes(json.getString(i));
 		}
 		//
-		return flattern(bytes);
+		return bytes;
 	}
 
-	public static BigInteger parseValueArray(JSONArray json) throws JSONException {
-		if(json.length() != 1) {
-			// NOTE: am unsure why a value array would have more than one element.
-			throw new IllegalArgumentException("invalid value array");
+	public static BigInteger[] parseValueArray(JSONArray json) throws JSONException {
+		BigInteger[] values = new BigInteger[json.length()];
+		for(int i=0;i!=json.length();++i) {
+			values[i] = Hex.toBigInt(json.getString(i));
 		}
-		return Hex.toBigInt(json.getString(0));
-	}
-
-	/**
-	 * Flattern a two dimensional byte array into a one dimensional byte array.
-	 *
-	 * @param bytes
-	 * @return
-	 */
-	private static byte[] flattern(byte[][] bytes) {
-		int n = 0;
-		for (int i = 0; i != bytes.length; ++i) {
-			n += bytes[i].length;
-		}
-		byte[] result = new byte[n];
-		int m = 0;
-		for (int i = 0; i != bytes.length; ++i) {
-			byte[] ith = bytes[i];
-			System.arraycopy(ith, 0, result, m, ith.length);
-			m = m + ith.length;
-		}
-		return result;
+		return values;
 	}
 }

--- a/src/main/java/dafnyevm/util/Tracers.java
+++ b/src/main/java/dafnyevm/util/Tracers.java
@@ -94,9 +94,9 @@ public class Tracers {
 	}
 
 	public static class Structured extends DafnyEvm.TraceAdaptor {
-		private final List<Trace> out;
+		private final List<Trace.Element> out;
 
-		public Structured(List<Trace> out) {
+		public Structured(List<Trace.Element> out) {
 			this.out = out;
 		}
 


### PR DESCRIPTION
This pushes through a fix for running the state tests.  Specifically, it
now correctly handles the parameterisation found in these tests, where
this exploits "indexes" to determine concrete values for data, gas and
value.

This also includes a number of other fixes to get the tests in stExample
to pass.  At this stage, there is one failure (which arises due to
    missing support for CALLVALUE) and some which are ignored (due to
      lack of machinery for gas calculations).