### PR TITLE
Follow Dafny Style Guide #84

### DIFF
--- a/src/dafny/util/bytes.dfy
+++ b/src/dafny/util/bytes.dfy
@@ -20,7 +20,7 @@ module Bytes {
      * Read the byte at a given address in Memory.  If the given location
      * has not been initialised, then zero is returned as default.
      */
-    function method read_u8(mem:seq<u8>, address:nat) : u8 {
+    function method ReadUint8(mem:seq<u8>, address:nat) : u8 {
         // Read location
         if address < |mem|
         then
@@ -34,9 +34,9 @@ module Bytes {
      * big-endian addressing.  If the read overflows the available
      * data, then it is padded with zeros.
      */
-    function method read_u16(mem:seq<u8>, address:nat) : u16 {
-        var w1 := read_u8(mem,address) as u16;
-        var w2 := read_u8(mem,address+1) as u16;
+    function method ReadUint16(mem:seq<u8>, address:nat) : u16 {
+        var w1 := ReadUint8(mem,address) as u16;
+        var w2 := ReadUint8(mem,address+1) as u16;
         (w1 * (TWO_8 as u16)) + w2
     }
 
@@ -44,9 +44,9 @@ module Bytes {
      * Read a 32bit word from a given address in Memory assuming
      * big-endian addressing.
      */
-    function method read_u32(mem:seq<u8>, address:nat) : u32 {
-        var w1 := read_u16(mem,address) as u32;
-        var w2 := read_u16(mem,address+2) as u32;
+    function method ReadUint32(mem:seq<u8>, address:nat) : u32 {
+        var w1 := ReadUint16(mem,address) as u32;
+        var w2 := ReadUint16(mem,address+2) as u32;
         (w1 * (TWO_16 as u32)) + w2
     }
 
@@ -55,9 +55,9 @@ module Bytes {
      * big-endian addressing.  If the read overflows the available
      * data, then it is padded with zeros.
      */
-    function method read_u64(mem:seq<u8>, address:nat) : u64 {
-        var w1 := read_u32(mem,address) as u64;
-        var w2 := read_u32(mem,address+4) as u64;
+    function method ReadUint64(mem:seq<u8>, address:nat) : u64 {
+        var w1 := ReadUint32(mem,address) as u64;
+        var w2 := ReadUint32(mem,address+4) as u64;
         (w1 * (TWO_32 as u64)) + w2
     }
 
@@ -66,9 +66,9 @@ module Bytes {
      * big-endian addressing.  If the read overflows the available
      * data, then it is padded with zeros.
      */
-    function method read_u128(mem:seq<u8>, address:nat) : u128 {
-        var w1 := read_u64(mem,address) as u128;
-        var w2 := read_u64(mem,address+8) as u128;
+    function method ReadUint128(mem:seq<u8>, address:nat) : u128 {
+        var w1 := ReadUint64(mem,address) as u128;
+        var w2 := ReadUint64(mem,address+8) as u128;
         (w1 * (TWO_64 as u128)) + w2
     }
 
@@ -77,9 +77,9 @@ module Bytes {
      * big-endian addressing.  If the read overflows the available
      * data, then it is padded with zeros.
      */
-    function method read_u256(mem:seq<u8>, address:nat) : u256 {
-        var w1 := read_u128(mem,address) as u256;
-        var w2 := read_u128(mem,address+16) as u256;
+    function method ReadUint256(mem:seq<u8>, address:nat) : u256 {
+        var w1 := ReadUint128(mem,address) as u256;
+        var w2 := ReadUint128(mem,address+16) as u256;
         (w1 * (TWO_128 as u256)) + w2
     }
 
@@ -88,17 +88,17 @@ module Bytes {
      * If the requested subsequence overflows available memory,
      * it is padded out with zeros.
      */
-    function method slice(mem:seq<u8>, address:nat, len:nat) : seq<u8> {
+    function method Slice(mem:seq<u8>, address:nat, len:nat) : seq<u8> {
       var n := address + len;
       // Sanity check for overflow
       if n <= |mem| then mem[address..n]
       // Yes overflow, so manage it.
-      else if address < |mem| then mem[address..] + padding(n-|mem|)
-      else padding(len)
+      else if address < |mem| then mem[address..] + Padding(n-|mem|)
+      else Padding(len)
     }
 
     /**
      * Construct a sequence of an arbitrary sized padded out with zeros.
      */
-    function method padding(n:nat) : seq<u8> { seq(n, i => 0) }
+    function method Padding(n:nat) : seq<u8> { seq(n, i => 0) }
 }

--- a/src/dafny/util/code.dfy
+++ b/src/dafny/util/code.dfy
@@ -31,7 +31,7 @@ module Code {
   /**
    * Create a code segment from an initial sequence of words.
    */
-  function method create(contents:seq<u8>) : T
+  function method Create(contents:seq<u8>) : T
     requires |contents| <= MAX_U256 {
         Code(contents:=contents)
   }
@@ -39,20 +39,20 @@ module Code {
   /**
    * Get the size of this code segment.
    */
-  function method size(c:T) : u256 { |c.contents| as u256 }
+  function method Size(c:T) : u256 { |c.contents| as u256 }
 
-  function method decode_u8(c:T, address:nat) : u8
+  function method DecodeUint8(c:T, address:nat) : u8
     // Decode position must be valid.
     requires address < |c.contents| {
       // Read word at given location
       c.contents[address]
   }
 
-  function method decode_u16(c:T, address:nat) : u16
+  function method DecodeUint16(c:T, address:nat) : u16
     // Decode position must be valid.
     requires address+1 < |c.contents| {
-      var k1 := decode_u8(c,address) as u16;
-      var k2 := decode_u8(c,address+1) as u16;
+      var k1 := DecodeUint8(c,address) as u16;
+      var k2 := DecodeUint8(c,address+1) as u16;
       (k1 * 256) + k2
   }
 }

--- a/src/dafny/util/context.dfy
+++ b/src/dafny/util/context.dfy
@@ -38,7 +38,7 @@ module Context {
     /**
      * Create an initial context from various components.
      */
-    function method create(origin:u160,calldata:seq<u8>) : T
+    function method Create(origin:u160,calldata:seq<u8>) : T
     requires |calldata| <= MAX_U256 {
         Context(address:=origin,origin:=origin,caller:=origin,calldata:=calldata)
     }
@@ -46,21 +46,21 @@ module Context {
     /**
      * Determine the size (in bytes) of the call data associated with this context.
      */
-    function method data_size(ctx: T) : u256 {
+    function method DataSize(ctx: T) : u256 {
       |ctx.calldata| as u256
     }
 
     /**
      * Read a word from the call data associated with this context.
      */
-    function method data_read(ctx: T, loc: u256) : u256 {
-      Bytes.read_u256(ctx.calldata,loc as nat)
+    function method DataRead(ctx: T, loc: u256) : u256 {
+      Bytes.ReadUint256(ctx.calldata,loc as nat)
     }
 
     /**
      * Slice a sequence of bytes from the call data associated with this context.
      */
-    function method data_slice(ctx: T, loc: u256, len: u256) : seq<u8> {
-      Bytes.slice(ctx.calldata,loc as nat, len as nat)
+    function method DataSlice(ctx: T, loc: u256, len: u256) : seq<u8> {
+      Bytes.Slice(ctx.calldata,loc as nat, len as nat)
     }
 }

--- a/src/dafny/util/int.dfy
+++ b/src/dafny/util/int.dfy
@@ -69,29 +69,29 @@ module Int {
   // Conversion to/from byte sequences
   // =========================================================
 
-  function method read_u8(bytes: seq<u8>, address:nat) : u8
+  function method ReadUint8(bytes: seq<u8>, address:nat) : u8
   requires address < |bytes| {
     bytes[address]
   }
 
-  function method read_u16(bytes: seq<u8>, address:nat) : u16
+  function method ReadUint16(bytes: seq<u8>, address:nat) : u16
   requires (address+1) < |bytes| {
     var b1 := bytes[address] as u16;
     var b2 := bytes[address+1] as u16;
     (b1 * (TWO_8 as u16)) + b2
   }
 
-  function method read_u32(bytes: seq<u8>, address:nat) : u32
+  function method ReadUint32(bytes: seq<u8>, address:nat) : u32
   requires (address+3) < |bytes| {
-    var b1 := read_u16(bytes, address) as u32;
-    var b2 := read_u16(bytes, address+2) as u32;
+    var b1 := ReadUint16(bytes, address) as u32;
+    var b2 := ReadUint16(bytes, address+2) as u32;
     (b1 * (TWO_16 as u32)) + b2
   }
 
-  function method read_u64(bytes: seq<u8>, address:nat) : u64
+  function method ReadUint64(bytes: seq<u8>, address:nat) : u64
   requires (address+7) < |bytes| {
-    var b1 := read_u32(bytes, address) as u64;
-    var b2 := read_u32(bytes, address+4) as u64;
+    var b1 := ReadUint32(bytes, address) as u64;
+    var b2 := ReadUint32(bytes, address+4) as u64;
     (b1 * (TWO_32 as u64)) + b2
   }
 
@@ -104,19 +104,19 @@ module Int {
   // because Dafny (unlike just about every other programming
   // language) supports Euclidean division.  This operator, therefore,
   // always divides *towards* zero.
-  function method div(lhs: int, rhs: int) : int
+  function method Div(lhs: int, rhs: int) : int
   requires rhs != 0 {
     if lhs >= 0 then lhs / rhs
     else
       -((-lhs) / rhs)
   }
 
-  // This provides a non-Euclidean remainder operator and is necessary
+  // This provides a non-Euclidean Remainder operator and is necessary
   // because Dafny (unlike just about every other programming
   // language) supports Euclidean division.  Observe that this is a
-  // true remainder operator, and not a modulus operator.  For
+  // true Remainder operator, and not a modulus operator.  For
   // emxaple, this means the result can be negative.
-  function method rem(lhs: int, rhs: int) : int
+  function method Rem(lhs: int, rhs: int) : int
   requires rhs != 0 {
     if lhs >= 0 then (lhs % rhs)
     else
@@ -125,51 +125,51 @@ module Int {
   }
 
   // Various sanity tests for division.
-  method div_tests() {
+  method DivTests() {
     // pos-pos
-    assert div(6,2) == 3;
-    assert div(6,3) == 2;
-    assert div(6,4) == 1;
-    assert div(9,4) == 2;
+    assert Div(6,2) == 3;
+    assert Div(6,3) == 2;
+    assert Div(6,4) == 1;
+    assert Div(9,4) == 2;
     // neg-pos
-    assert div(-6,2) == -3;
-    assert div(-6,3) == -2;
-    assert div(-6,4) == -1;
-    assert div(-9,4) == -2;
+    assert Div(-6,2) == -3;
+    assert Div(-6,3) == -2;
+    assert Div(-6,4) == -1;
+    assert Div(-9,4) == -2;
     // pos-neg
-    assert div(6,-2) == -3;
-    assert div(6,-3) == -2;
-    assert div(6,-4) == -1;
-    assert div(9,-4) == -2;
+    assert Div(6,-2) == -3;
+    assert Div(6,-3) == -2;
+    assert Div(6,-4) == -1;
+    assert Div(9,-4) == -2;
     // neg-neg
-    assert div(-6,-2) == 3;
-    assert div(-6,-3) == 2;
-    assert div(-6,-4) == 1;
-    assert div(-9,-4) == 2;
+    assert Div(-6,-2) == 3;
+    assert Div(-6,-3) == 2;
+    assert Div(-6,-4) == 1;
+    assert Div(-9,-4) == 2;
   }
 
-  // Various sanity tests for remainder.
-  method rem_tests() {
+  // Various sanity tests for Remainder.
+  method RemTests() {
     // pos-pos
-    assert rem(6,2) == 0;
-    assert rem(6,3) == 0;
-    assert rem(6,4) == 2;
-    assert rem(9,4) == 1;
+    assert Rem(6,2) == 0;
+    assert Rem(6,3) == 0;
+    assert Rem(6,4) == 2;
+    assert Rem(9,4) == 1;
     // neg-pos
-    assert rem(-6,2) == 0;
-    assert rem(-6,3) == 0;
-    assert rem(-6,4) == -2;
-    assert rem(-9,4) == -1;
+    assert Rem(-6,2) == 0;
+    assert Rem(-6,3) == 0;
+    assert Rem(-6,4) == -2;
+    assert Rem(-9,4) == -1;
     // pos-neg
-    assert rem(6,-2) == 0;
-    assert rem(6,-3) == 0;
-    assert rem(6,-4) == 2;
-    assert rem(9,-4) == 1;
+    assert Rem(6,-2) == 0;
+    assert Rem(6,-3) == 0;
+    assert Rem(6,-4) == 2;
+    assert Rem(9,-4) == 1;
     // neg-neg
-    assert rem(-6,-2) == 0;
-    assert rem(-6,-3) == 0;
-    assert rem(-6,-4) == -2;
-    assert rem(-9,-4) == -1;
+    assert Rem(-6,-2) == 0;
+    assert Rem(-6,-3) == 0;
+    assert Rem(-6,-4) == -2;
+    assert Rem(-9,-4) == -1;
   }
 }
 
@@ -181,7 +181,7 @@ module U16 {
 
   // Read nth 8bit word (i.e. byte) out of this u16, where 0
   // identifies the most significant byte.
-  function method nth_u8(v:u16, k: nat) : u8
+  function method NthUint8(v:u16, k: nat) : u8
     // Cannot read more than two words!
   requires k < 2 {
     if k == 0
@@ -190,9 +190,9 @@ module U16 {
         (v % (TWO_8 as u16)) as u8
   }
 
-  method tests_nth_u8() {
-    assert nth_u8(0xde80,0) == 0xde;
-    assert nth_u8(0xde80,1) == 0x80;
+  method tests_NthUint8() {
+    assert NthUint8(0xde80,0) == 0xde;
+    assert NthUint8(0xde80,1) == 0x80;
   }
 }
 
@@ -204,7 +204,7 @@ module U32 {
 
   // Read nth 16bit word out of this u32, where 0 identifies the most
   // significant word.
-  function method nth_u16(v:u32, k: nat) : u16
+  function method NthUint16(v:u32, k: nat) : u16
     // Cannot read more than two words!
   requires k < 2 {
     if k == 0
@@ -213,9 +213,9 @@ module U32 {
         (v % (TWO_16 as u32)) as u16
   }
 
-  method tests_nth_u16() {
-    assert nth_u16(0x1230de80,0) == 0x1230;
-    assert nth_u16(0x1230de80,1) == 0xde80;
+  method tests_Nth_u16() {
+    assert NthUint16(0x1230de80,0) == 0x1230;
+    assert NthUint16(0x1230de80,1) == 0xde80;
   }
 }
 
@@ -227,7 +227,7 @@ module U64 {
 
   // Read nth 32bit word out of this u64, where 0 identifies the most
   // significant word.
-  function method nth_u32(v:u64, k: nat) : u32
+  function method NthUint32(v:u64, k: nat) : u32
     // Cannot read more than two words!
   requires k < 2 {
     if k == 0
@@ -236,9 +236,9 @@ module U64 {
         (v % (TWO_32 as u64)) as u32
   }
 
-  method tests_nth_u32() {
-    assert nth_u32(0x00112233_44556677,0) == 0x00112233;
-    assert nth_u32(0x00112233_44556677,1) == 0x44556677;
+  method testsNthUint32() {
+    assert NthUint32(0x00112233_44556677,0) == 0x00112233;
+    assert NthUint32(0x00112233_44556677,1) == 0x44556677;
   }
 }
 
@@ -250,7 +250,7 @@ module U128 {
 
   // Read nth 64bit word out of this u128, where 0 identifies the most
   // significant word.
-  function method nth_u64(v:u128, k: nat) : u64
+  function method NthUint64(v:u128, k: nat) : u64
     // Cannot read more than two words!
   requires k < 2 {
     if k == 0
@@ -259,9 +259,9 @@ module U128 {
         (v % (TWO_64 as u128)) as u64
   }
 
-  method tests_nth_u64() {
-    assert nth_u64(0x0011223344556677_8899AABBCCDDEEFF,0) == 0x0011223344556677;
-    assert nth_u64(0x0011223344556677_8899AABBCCDDEEFF,1) == 0x8899AABBCCDDEEFF;
+  method testsNthUint64() {
+    assert NthUint64(0x0011223344556677_8899AABBCCDDEEFF,0) == 0x0011223344556677;
+    assert NthUint64(0x0011223344556677_8899AABBCCDDEEFF,1) == 0x8899AABBCCDDEEFF;
   }
 }
 
@@ -277,7 +277,7 @@ module U256 {
 
   // Read nth 128bit word out of this u256, where 0 identifies the most
   // significant word.
-  function method nth_u128(v:u256, k: nat) : u128
+  function method NthUint128(v:u256, k: nat) : u128
     // Cannot read more than two words!
     requires k < 2 {
       if k == 0
@@ -288,57 +288,57 @@ module U256 {
 
   // Read nth byte out of this u256, where 0 identifies the most
   // significant byte.
-  function method nth_u8(v:u256, k: nat) : u8
+  function method NthUint8(v:u256, k: nat) : u8
     // Cannot read more than 32bytes!
     requires k < 32 {
       // This is perhaps a tad ugly.  Happy to take suggestions on
       // a better approach :)
-      var w128 := nth_u128(v,k / 16);
-      var w64 := U128.nth_u64(w128,(k % 16) / 8);
-      var w32 :=  U64.nth_u32(w64,(k % 8) / 4);
-      var w16 :=  U32.nth_u16(w32,(k % 4) / 2);
-      U16.nth_u8(w16,k%2)
+      var w128 := NthUint128(v,k / 16);
+      var w64 := U128.NthUint64(w128,(k % 16) / 8);
+      var w32 :=  U64.NthUint32(w64,(k % 8) / 4);
+      var w16 :=  U32.NthUint16(w32,(k % 4) / 2);
+      U16.NthUint8(w16,k%2)
   }
 
-  method tests_nth_u128() {
-    assert nth_u128(0x00112233445566778899AABBCCDDEEFF_FFEEDDCCBBAA99887766554433221100,0) == 0x00112233445566778899AABBCCDDEEFF;
-    assert nth_u128(0x00112233445566778899AABBCCDDEEFF_FFEEDDCCBBAA99887766554433221100,1) == 0xFFEEDDCCBBAA99887766554433221100;
+  method testsNthUint128() {
+    assert NthUint128(0x00112233445566778899AABBCCDDEEFF_FFEEDDCCBBAA99887766554433221100,0) == 0x00112233445566778899AABBCCDDEEFF;
+    assert NthUint128(0x00112233445566778899AABBCCDDEEFF_FFEEDDCCBBAA99887766554433221100,1) == 0xFFEEDDCCBBAA99887766554433221100;
   }
 
-  method tests_nth_u8() {
-    assert nth_u8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,00) == 0x00;
-    assert nth_u8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,01) == 0x01;
-    assert nth_u8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,02) == 0x02;
-    assert nth_u8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,03) == 0x03;
-    assert nth_u8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,04) == 0x04;
-    assert nth_u8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,05) == 0x05;
-    assert nth_u8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,06) == 0x06;
-    assert nth_u8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,07) == 0x07;
-    assert nth_u8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,08) == 0x08;
-    assert nth_u8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,09) == 0x09;
-    assert nth_u8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,10) == 0x0A;
-    assert nth_u8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,11) == 0x0B;
-    assert nth_u8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,12) == 0x0C;
-    assert nth_u8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,13) == 0x0D;
-    assert nth_u8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,14) == 0x0E;
-    assert nth_u8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,15) == 0x0F;
+  method testsNthUint8() {
+    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,00) == 0x00;
+    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,01) == 0x01;
+    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,02) == 0x02;
+    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,03) == 0x03;
+    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,04) == 0x04;
+    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,05) == 0x05;
+    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,06) == 0x06;
+    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,07) == 0x07;
+    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,08) == 0x08;
+    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,09) == 0x09;
+    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,10) == 0x0A;
+    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,11) == 0x0B;
+    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,12) == 0x0C;
+    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,13) == 0x0D;
+    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,14) == 0x0E;
+    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,15) == 0x0F;
     //
-    assert nth_u8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,16) == 0x10;
-    assert nth_u8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,17) == 0x11;
-    assert nth_u8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,18) == 0x12;
-    assert nth_u8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,19) == 0x13;
-    assert nth_u8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,20) == 0x14;
-    assert nth_u8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,21) == 0x15;
-    assert nth_u8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,22) == 0x16;
-    assert nth_u8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,23) == 0x17;
-    assert nth_u8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,24) == 0x18;
-    assert nth_u8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,25) == 0x19;
-    assert nth_u8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,26) == 0x1A;
-    assert nth_u8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,27) == 0x1B;
-    assert nth_u8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,28) == 0x1C;
-    assert nth_u8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,29) == 0x1D;
-    assert nth_u8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,30) == 0x1E;
-    assert nth_u8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,31) == 0x1F;
+    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,16) == 0x10;
+    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,17) == 0x11;
+    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,18) == 0x12;
+    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,19) == 0x13;
+    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,20) == 0x14;
+    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,21) == 0x15;
+    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,22) == 0x16;
+    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,23) == 0x17;
+    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,24) == 0x18;
+    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,25) == 0x19;
+    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,26) == 0x1A;
+    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,27) == 0x1B;
+    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,28) == 0x1C;
+    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,29) == 0x1D;
+    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,30) == 0x1E;
+    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,31) == 0x1F;
 
   }
 }
@@ -355,18 +355,18 @@ module I256 {
     requires rhs != 0
     // Range restriction to prevent overflow
     requires (rhs != -1 || lhs != (-TWO_255 as i256)) {
-    Int.div(lhs as int, rhs as int) as i256
+    Int.Div(lhs as int, rhs as int) as i256
   }
 
-  // This provides a non-Euclidean remainder operator and is necessary
+  // This provides a non-Euclidean Remainder operator and is necessary
   // because Dafny (unlike just about every other programming
   // language) supports Euclidean division.  Observe that this is a
-  // true remainder operator, and not a modulus operator.  For
+  // true Remainder operator, and not a modulus operator.  For
   // emxaple, this means the result can be negative.
-  function method rem(lhs: i256, rhs: i256) : i256
+  function method Rem(lhs: i256, rhs: i256) : i256
     // Cannot divide by zero!
     requires rhs != 0 {
-    Int.rem(lhs as int, rhs as int) as i256
+    Int.Rem(lhs as int, rhs as int) as i256
   }
 }
 

--- a/src/dafny/util/memory.dfy
+++ b/src/dafny/util/memory.dfy
@@ -28,7 +28,7 @@ module Memory {
     /**
      * Create a memory from an initial sequence of words.
      */
-    function method create() : T {
+    function method Create() : T {
         Memory(contents:=map[])
     }
 
@@ -36,7 +36,7 @@ module Memory {
      * Read the byte at a given address in Memory.  If the given location
      * has not been initialised, then zero is returned as default.
      */
-    function method read_u8(mem:T, address:u256) : u8 {
+    function method ReadUint8(mem:T, address:u256) : u8 {
         // Read location
         if address in mem.contents
         then
@@ -49,10 +49,10 @@ module Memory {
      * Read a 16bit word from a given address in Memory assuming
      * big-endian addressing.
      */
-    function method read_u16(mem:T, address:u256) : u16
+    function method ReadUint16(mem:T, address:u256) : u16
       requires (address as int) + 1 <= MAX_U256 {
-        var w1 := read_u8(mem,address) as u16;
-        var w2 := read_u8(mem,address+1) as u16;
+        var w1 := ReadUint8(mem,address) as u16;
+        var w2 := ReadUint8(mem,address+1) as u16;
         (w1 * (TWO_8 as u16)) + w2
     }
 
@@ -60,10 +60,10 @@ module Memory {
      * Read a 32bit word from a given address in Memory assuming
      * big-endian addressing.
      */
-    function method read_u32(mem:T, address:u256) : u32
+    function method ReadUint32(mem:T, address:u256) : u32
       requires (address as int) + 3 <= MAX_U256 {
-        var w1 := read_u16(mem,address) as u32;
-        var w2 := read_u16(mem,address+2) as u32;
+        var w1 := ReadUint16(mem,address) as u32;
+        var w2 := ReadUint16(mem,address+2) as u32;
         (w1 * (TWO_16 as u32)) + w2
     }
 
@@ -71,10 +71,10 @@ module Memory {
      * Read a 64bit word from a given address in Memory assuming
      * big-endian addressing.
      */
-    function method read_u64(mem:T, address:u256) : u64
+    function method ReadUint64(mem:T, address:u256) : u64
       requires (address as int) + 7 <= MAX_U256 {
-        var w1 := read_u32(mem,address) as u64;
-        var w2 := read_u32(mem,address+4) as u64;
+        var w1 := ReadUint32(mem,address) as u64;
+        var w2 := ReadUint32(mem,address+4) as u64;
         (w1 * (TWO_32 as u64)) + w2
     }
 
@@ -82,10 +82,10 @@ module Memory {
      * Read a 128bit word from a given address in Memory assuming
      * big-endian addressing.
      */
-    function method read_u128(mem:T, address:u256) : u128
+    function method ReadUint128(mem:T, address:u256) : u128
       requires (address as int) + 15 <= MAX_U256 {
-        var w1 := read_u64(mem,address) as u128;
-        var w2 := read_u64(mem,address+8) as u128;
+        var w1 := ReadUint64(mem,address) as u128;
+        var w2 := ReadUint64(mem,address+8) as u128;
         (w1 * (TWO_64 as u128)) + w2
     }
 
@@ -93,17 +93,17 @@ module Memory {
      * Read a 256bit word from a given address in Memory assuming
      * big-endian addressing.
      */
-    function method read_u256(mem:T, address:u256) : u256
+    function method ReadUint256(mem:T, address:u256) : u256
       requires (address as int) + 31 <= MAX_U256 {
-        var w1 := read_u128(mem,address) as u256;
-        var w2 := read_u128(mem,address+16) as u256;
+        var w1 := ReadUint128(mem,address) as u256;
+        var w2 := ReadUint128(mem,address+16) as u256;
         (w1 * (TWO_128 as u256)) + w2
     }
 
     /**
      * Write a byte to a given address in Memory.
      */
-    function method write_u8(mem:T, address:u256, val:u8) : T {
+    function method WriteUint8(mem:T, address:u256, val:u8) : T {
         // Write location
         Memory(contents:=mem.contents[address:=val])
     }
@@ -112,67 +112,67 @@ module Memory {
      * Write a 16bit word to a given address in Memory using
      * big-endian addressing.
      */
-    function method write_u16(mem:T, address:u256, val:u16) : T
+    function method WriteUint16(mem:T, address:u256, val:u16) : T
     requires (address as int) + 1 <= MAX_U256 {
       var w1 := val / (TWO_8 as u16);
       var w2 := val % (TWO_8 as u16);
-      var mem' := write_u8(mem,address,w1 as u8);
-      write_u8(mem',address+1,w2 as u8)
+      var mem' := WriteUint8(mem,address,w1 as u8);
+      WriteUint8(mem',address+1,w2 as u8)
     }
 
     /**
      * Write a 32bit word to a given address in Memory using
      * big-endian addressing.
      */
-    function method write_u32(mem:T, address:u256, val:u32) : T
+    function method WriteUint32(mem:T, address:u256, val:u32) : T
     requires (address as int) + 3 <= MAX_U256 {
       var w1 := val / (TWO_16 as u32);
       var w2 := val % (TWO_16 as u32);
-      var mem' := write_u16(mem,address,w1 as u16);
-      write_u16(mem',address+2,w2 as u16)
+      var mem' := WriteUint16(mem,address,w1 as u16);
+      WriteUint16(mem',address+2,w2 as u16)
     }
 
     /**
      * Write a 64bit word to a given address in Memory using
      * big-endian addressing.
      */
-    function method write_u64(mem:T, address:u256, val:u64) : T
+    function method WriteUint64(mem:T, address:u256, val:u64) : T
     requires (address as int) + 7 <= MAX_U256 {
       var w1 := val / (TWO_32 as u64);
       var w2 := val % (TWO_32 as u64);
-      var mem' := write_u32(mem,address,w1 as u32);
-      write_u32(mem',address+4,w2 as u32)
+      var mem' := WriteUint32(mem,address,w1 as u32);
+      WriteUint32(mem',address+4,w2 as u32)
     }
 
     /**
      * Write a 128bit word to a given address in Memory using
      * big-endian addressing.
      */
-    function method write_u128(mem:T, address:u256, val:u128) : T
+    function method WriteUint128(mem:T, address:u256, val:u128) : T
     requires (address as int) + 15 <= MAX_U256 {
       var w1 := val / (TWO_64 as u128);
       var w2 := val % (TWO_64 as u128);
-      var mem' := write_u64(mem,address,w1 as u64);
-      write_u64(mem',address+8,w2 as u64)
+      var mem' := WriteUint64(mem,address,w1 as u64);
+      WriteUint64(mem',address+8,w2 as u64)
     }
 
     /**
      * Write a 256bit word to a given address in Memory using
      * big-endian addressing.
      */
-    function method write_u256(mem:T, address:u256, val:u256) : T
+    function method WriteUint256(mem:T, address:u256, val:u256) : T
     requires (address as int) + 31 <= MAX_U256 {
       var w1 := val / (TWO_128 as u256);
       var w2 := val % (TWO_128 as u256);
-      var mem' := write_u128(mem,address,w1 as u128);
-      write_u128(mem',address+16,w2 as u128)
+      var mem' := WriteUint128(mem,address,w1 as u128);
+      WriteUint128(mem',address+16,w2 as u128)
     }
 
     /**
      * Slice out a section of memory.  This is implemented in a subdivision
      * style as this seems to work better (in terms of theorem prover performance).
      */
-    function method slice(mem:T, address:u256, len:nat) : seq<u8>
+    function method Slice(mem:T, address:u256, len:nat) : seq<u8>
       requires (address as int + len) <= MAX_U256
       decreases len
     {
@@ -181,25 +181,25 @@ module Memory {
         []
       else if len == 1
         then
-        [read_u8(mem,address)]
+        [ReadUint8(mem,address)]
       else
         var pivot := len / 2;
         var middle := address + (pivot as u256);
-        slice(mem,address,pivot) + slice(mem,middle, len - pivot)
+        Slice(mem,address,pivot) + Slice(mem,middle, len - pivot)
     }
 
     /**
      * Copy a sequence of bytes into this memory at a given address.
      */
-    function method copy(mem:T, address:u256, data:seq<u8>) : T
+    function method Copy(mem:T, address:u256, data:seq<u8>) : T
       requires (address as int + |data|) <= MAX_U256
       decreases |data| {
         if |data| == 0 then mem
-        else if |data| == 1 then write_u8(mem,address,data[0])
+        else if |data| == 1 then WriteUint8(mem,address,data[0])
         else
           var pivot := |data| / 2;
           var middle := address + (pivot as u256);
-          var nmem := copy(mem,address,data[0..pivot]);
-          copy(nmem,middle,data[pivot..])
+          var nmem := Copy(mem,address,data[0..pivot]);
+          Copy(nmem,middle,data[pivot..])
     }
 }

--- a/src/dafny/util/stack.dfy
+++ b/src/dafny/util/stack.dfy
@@ -27,44 +27,44 @@ module Stack {
     witness Stack([])
 
     // Get number of items currently on this Stack.
-    function method size(st:T) : nat { |st.contents| }
+    function method Size(st:T) : nat { |st.contents| }
 
     // Get remaining capacity of stack (i.e. number of items we could
     // still push).
-    function method capacity(st:T) : nat {
+    function method Capacity(st:T) : nat {
       CAPACITY - |st.contents|
     }
 
     // Create an empty stack.
-    function method create() : T { Stack(contents:=[]) }
+    function method Create() : T { Stack(contents:=[]) }
 
     // Push word onto Stack.  This requires that there is sufficient
     // space for that item.
-    function method push(st:T, val:u256) : T
+    function method Push(st:T, val:u256) : T
         // Sanity check enough space.
-        requires size(st) < CAPACITY {
+        requires Size(st) < CAPACITY {
             Stack(contents:=([val] + st.contents))
     }
 
     // Peek nth word from top of Stack (where 0 is top item, 1 is next
     // item, and so on).  This requires there are sufficiently many
     // words.
-    function method peek(st:T, k:int) : u256
+    function method Peek(st:T, k:int) : u256
         // Sanity check enough items to pop!
-        requires k >= 0 && k < size(st) {
+        requires k >= 0 && k < Size(st) {
             st.contents[k]
     }
 
     // Pop word off of this Stack.  This requires something to pop!
-    function method pop(st:T) : T
+    function method Pop(st:T) : T
         // Sanity check something to pop.
-        requires size(st) > 0 {
+        requires Size(st) > 0 {
             Stack(contents:=st.contents[1..])
     }
 
     // Swap top item and kth item
-    function method swap(st:T, k:nat) : T
-      requires size(st) > k {
+    function method Swap(st:T, k:nat) : T
+      requires Size(st) > k {
         var top := st.contents[0];
         var kth := st.contents[k];
         Stack(contents:=st.contents[0:=kth][k:=top])

--- a/src/dafny/util/storage.dfy
+++ b/src/dafny/util/storage.dfy
@@ -28,7 +28,7 @@ module Storage {
     /**
      * Create some storage from an initial sequence of words.
      */
-    function method create(contents:map<u256,u256>) : T {
+    function method Create(contents:map<u256,u256>) : T {
         Storage(contents:=contents)
     }
 
@@ -36,7 +36,7 @@ module Storage {
      * Read the value at a given address in Storage.  If the given location
      * has not been initialised, then zero is returned as default.
      */
-    function method read(mem:T, address:u256) : u256 {
+    function method Read(mem:T, address:u256) : u256 {
       if address in mem.contents
         then
         mem.contents[address]
@@ -47,7 +47,7 @@ module Storage {
     /**
      * Write a value to a given address in Storage.
      */
-    function method write(mem:T, address:u256, val:u256) : T {
+    function method Write(mem:T, address:u256, val:u256) : T {
         Storage(contents:=mem.contents[address:=val])
     }
 }

--- a/src/main/java/dafnyevm/DafnyEvm.java
+++ b/src/main/java/dafnyevm/DafnyEvm.java
@@ -13,8 +13,8 @@
  */
 package dafnyevm;
 
-import static EVM_Compile.__default.create;
-import static EVM_Compile.__default.execute;
+import static EVM_Compile.__default.Create;
+import static EVM_Compile.__default.Execute;
 
 import java.math.BigInteger;
 import java.util.Map;
@@ -83,16 +83,16 @@ public class DafnyEvm {
 	 */
 	public SnapShot call(BigInteger from, byte[] calldata) {
 		// Create call context.
-		Context_Compile.Raw ctx = Context_Compile.__default.create(from, DafnySequence.fromBytes(calldata));
+		Context_Compile.Raw ctx = Context_Compile.__default.Create(from, DafnySequence.fromBytes(calldata));
 		// Create the EVM
-		State r = create(ctx, storage, BigInteger.ONE, code);
+		State r = Create(ctx, storage, BigInteger.ONE, code);
 		// Execute it!
 		tracer.step(r);
-		r = execute(r);
+		r = Execute(r);
 		// Continue whilst the EVM is happy.
 		while(r instanceof State_OK) {
 			tracer.step(r);
-			r = execute(r);
+			r = Execute(r);
 		}
 		// Final step
 		tracer.step(r);

--- a/src/test/dafny/test.dfy
+++ b/src/test/dafny/test.dfy
@@ -7,24 +7,24 @@ import opened EVM
 const GASLIMIT : nat := 100;
 
 // Check most simple program possible
-method test_execute_01(x: u8)
+method test_Execute_01(x: u8)
 requires x > 1
 {
   // Initialise EVM
-  var tx := Context.create(0xabcd,[]);
-  var vm := EVM.create(tx,map[],GASLIMIT,[PUSH1, x, PUSH1, 0x0, MSTORE, PUSH1, 0x1, PUSH1, 0x1F, RETURN]);
+  var tx := Context.Create(0xabcd,[]);
+  var vm := EVM.Create(tx,map[],GASLIMIT,[PUSH1, x, PUSH1, 0x0, MSTORE, PUSH1, 0x1, PUSH1, 0x1F, RETURN]);
   // PUSH1 x
-  vm := EVM.execute(vm);
+  vm := EVM.Execute(vm);
   // PUSH1 0x2
-  vm := EVM.execute(vm);
+  vm := EVM.Execute(vm);
   // MSTORE
-  vm := EVM.execute(vm);
+  vm := EVM.Execute(vm);
   // PUSH
-  vm := EVM.execute(vm);
+  vm := EVM.Execute(vm);
   // PUSH
-  vm := EVM.execute(vm);
+  vm := EVM.Execute(vm);
   // RETURN
-  vm := EVM.execute(vm);
+  vm := EVM.Execute(vm);
   //
   assert vm.data == [x];
 }
@@ -37,8 +37,8 @@ requires x > 1
 method test_basic_01(x: u8)
 requires x > 1
 {
-  var tx := Context.create(0xabcd,[]);
-  var vm := EVM.create(tx,map[],GASLIMIT,[PUSH1, x, PUSH1, 0x0, MSTORE, PUSH1, 0x1, PUSH1, 0x1F, RETURN]);
+  var tx := Context.Create(0xabcd,[]);
+  var vm := EVM.Create(tx,map[],GASLIMIT,[PUSH1, x, PUSH1, 0x0, MSTORE, PUSH1, 0x1, PUSH1, 0x1F, RETURN]);
   //
   vm := EVM.Push1(vm,x);
   vm := EVM.Push1(vm,0);
@@ -54,8 +54,8 @@ requires x > 1
 method test_basic_02(x: u8, y: u8) returns (z:u16)
 ensures z == (x as u16) + (y as u16)
 {
-  var tx := Context.create(0xabcd,[]);
-  var vm := EVM.create(tx,map[],GASLIMIT,[PUSH1, x, PUSH1, y, ADD, PUSH1, 0x0, MSTORE, PUSH1, 0x2, PUSH1, 0x1E, RETURN]);
+  var tx := Context.Create(0xabcd,[]);
+  var vm := EVM.Create(tx,map[],GASLIMIT,[PUSH1, x, PUSH1, y, ADD, PUSH1, 0x0, MSTORE, PUSH1, 0x2, PUSH1, 0x1E, RETURN]);
   //
   vm := EVM.Push1(vm,x);
   vm := EVM.Push1(vm,y);
@@ -67,15 +67,15 @@ ensures z == (x as u16) + (y as u16)
   vm := EVM.Push1(vm,0x1E);
   vm := EVM.Return(vm);
   //
-  return Bytes.read_u16(vm.data,0);
+  return Bytes.ReadUint16(vm.data,0);
 }
 
 method test_basic_03(x: u8, y: u8) returns (z:u8)
 requires x >= y
 ensures z <= x
 {
-  var tx := Context.create(0xabcd,[]);
-  var vm := EVM.create(tx,map[],GASLIMIT,[PUSH1, y, PUSH1, x, SUB, PUSH1, 0x0, MSTORE, PUSH1, 0x1, PUSH1, 0x1F, RETURN]);
+  var tx := Context.Create(0xabcd,[]);
+  var vm := EVM.Create(tx,map[],GASLIMIT,[PUSH1, y, PUSH1, x, SUB, PUSH1, 0x0, MSTORE, PUSH1, 0x1, PUSH1, 0x1F, RETURN]);
   //
   vm := EVM.Push1(vm,y);
   vm := EVM.Push1(vm,x);
@@ -86,7 +86,7 @@ ensures z <= x
   vm := EVM.Push1(vm,0x1F);
   vm := EVM.Return(vm);
   //
-  return Bytes.read_u8(vm.data,0);
+  return Bytes.ReadUint8(vm.data,0);
 }
 
 // ===========================================================================
@@ -100,8 +100,8 @@ method test_branch_01(x: u8, y: u8) returns (z:u8, revert:bool)
   // If didn't revert, then result is less.
   ensures !revert ==> (z <= x)
 {
-  var tx := Context.create(0xabcd,[]);
-  var vm := EVM.create(tx,map[],GASLIMIT,[PUSH1, x, PUSH1, y, GT, ISZERO, PUSH1, 0x0A, JUMPI, REVERT, JUMPDEST, PUSH1, x, PUSH1, y, SUB, PUSH1, 0x0, MSTORE, PUSH1, 0x1, PUSH1, 0x1F, RETURN]);
+  var tx := Context.Create(0xabcd,[]);
+  var vm := EVM.Create(tx,map[],GASLIMIT,[PUSH1, x, PUSH1, y, GT, ISZERO, PUSH1, 0x0A, JUMPI, REVERT, JUMPDEST, PUSH1, x, PUSH1, y, SUB, PUSH1, 0x0, MSTORE, PUSH1, 0x1, PUSH1, 0x1F, RETURN]);
   //
   vm := EVM.Push1(vm,x);   // 0x00
   vm := EVM.Push1(vm,y);   // 0x02
@@ -126,7 +126,7 @@ method test_branch_01(x: u8, y: u8) returns (z:u8, revert:bool)
     vm := EVM.Push1(vm,0x1F);
     vm := EVM.Return (vm);
     //
-    return Bytes.read_u8(vm.data,0), false;
+    return Bytes.ReadUint8(vm.data,0), false;
   }
 }
 


### PR DESCRIPTION
This updates the majority of the codebase to follow the Dafny style
guide.  That means, for example, changing function/method identifiers to
be in PascalCase.  At this stage, I did not change:

(1) Low-level integer datatypes (e.g. u8, u16, etc)

(2) Microcodes within EVM module (unfortunately there are name clashes
    here).

After breaking up the codebase a bit more, we should hopefully be able
to resolve (2) above.