### PR TITLE
Suppress compiler output #100

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ task compileDafny {
         // Generate Dafny Source
         exec {
             executable 'dafny'
-            args '/verifyAllModules','/out:evm','/compileTarget:java', 'src/dafny/evm.dfy'
+            args '/verifyAllModules','/out:evm','/compileTarget:java','/compileVerbose:0','src/dafny/evm.dfy'
         }
     }
 }
@@ -59,7 +59,7 @@ task testDafny {
             File file -> {
                 exec {
                     executable 'dafny'
-                    args '/runAllTests:1','/out:tmp','/compileTarget:java','/compile:4',file
+                    args '/runAllTests:1','/out:tmp','/compileTarget:java','/compile:4','/compileVerbose:0',file
                 }
             }
         }


### PR DESCRIPTION
This adds the option `/compileVerbose:0` at various points in the gradle
build.