### PR TITLE
Implement SAR #40

### DIFF
--- a/src/dafny/bytecode.dfy
+++ b/src/dafny/bytecode.dfy
@@ -396,35 +396,49 @@ module Bytecode {
     }
 
     /**
-    * Left shift operation.
-    */
+     * Left shift operation.
+     */
     function method Shl(st: State) : State
     requires !st.IsFailure() {
         //
         if st.Operands() >= 2
         then
-            var lhs := st.Peek(0);
-            var rhs := st.Peek(1) as bv256;
-            // NOTE: unclear whether shifting is optimal choice here.
-            var res := if lhs < 256 then (rhs << lhs) else 0;
-            st.Pop().Pop().Push(res as u256).Next()
+            var rhs := st.Peek(0);
+            var lhs := st.Peek(1);
+            var res := U256.Shl(lhs,rhs);
+            st.Pop().Pop().Push(res).Next()
         else
             State.INVALID
     }
 
     /**
-    * Right shift operation.
-    */
+     * Right shift operation.
+     */
     function method {:verify false} Shr(st: State) : State
     requires !st.IsFailure() {
         //
         if st.Operands() >= 2
         then
-            var lhs := st.Peek(0);
-            var rhs := st.Peek(1) as bv256;
-            // NOTE: unclear whether shifting is optimal choice here.
-            var res := if lhs < 256 then (rhs >> lhs) else 0;
-            st.Pop().Pop().Push(res as u256).Next()
+            var rhs := st.Peek(0);
+            var lhs := st.Peek(1);
+            var res := U256.Shr(lhs,rhs);
+            st.Pop().Pop().Push(res).Next()
+        else
+            State.INVALID
+    }
+
+    /**
+     * Arithmetic (signed) right shift operation.
+     */
+    function method Sar(st: State) : State
+    requires !st.IsFailure() {
+        //
+        if st.Operands() >= 2
+        then
+            var rhs := st.Peek(0);
+            var lhs := Word.asI256(st.Peek(1));
+            var res := I256.Sar(lhs,rhs);
+            st.Pop().Pop().Push(res).Next()
         else
             State.INVALID
     }

--- a/src/dafny/evms/berlin.dfy
+++ b/src/dafny/evms/berlin.dfy
@@ -85,7 +85,7 @@ module EvmBerlin refines EVM {
                         case BYTE =>  Bytecode.Byte(s)
                         case SHL =>  Bytecode.Shl(s)
                         case SHR =>  Bytecode.Shr(s)
-                        //  SAR => Some((s:OKState) => Bytecode.evalSAR(s),)
+                        case SAR => Bytecode.Sar(s)
                         // 0x20s
                         //  KECCAK256 =>  Some((s:OKState) => Bytecode.evalKECCAK256(s),)
                         // 0x30s: Environment Information
@@ -248,7 +248,7 @@ module EvmBerlin refines EVM {
             case BYTE =>  Some((s:OKState) => Bytecode.Byte(s))
             case SHL =>  Some((s:OKState) => Bytecode.Shl(s))
             case SHR =>  Some((s:OKState) => Bytecode.Shr(s))
-            //  SAR =>  Some((s:OKState) => Bytecode.evalSAR(s),)
+            case SAR =>  Some((s:OKState) => Bytecode.Sar(s))
             // 0x20s
             //  KECCAK256 =>  Some((s:OKState) => Bytecode.evalKECCAK256(s),)
             // 0x30s: Environment Information

--- a/src/dafny/gas.dfy
+++ b/src/dafny/gas.dfy
@@ -98,7 +98,7 @@ module Gas {
             case BYTE => s.UseGas(G_VERYLOW)
             case SHL => s.UseGas(G_VERYLOW)
             case SHR => s.UseGas(G_VERYLOW)
-            // SAR => s.UseGas(1)
+            case SAR => s.UseGas(G_VERYLOW)
             // 0x20s
             //  KECCAK256 => s.UseGas(1)
             // 0x30s: Environment Information

--- a/src/dafny/util/int.dfy
+++ b/src/dafny/util/int.dfy
@@ -12,123 +12,123 @@
  * under the License.
  */
 module Int {
-  // Powers of Two
-  const TWO_7   : int := 0x0_80;
-  const TWO_8   : int := 0x1_00;
-  const TWO_15  : int := 0x0_8000;
-  const TWO_16  : int := 0x1_0000;
-  const TWO_24  : int := 0x1_0000_00;
-  const TWO_31  : int := 0x0_8000_0000;
-  const TWO_32  : int := 0x1_0000_0000;
-  const TWO_40  : int := 0x1_0000_0000_00;
-  const TWO_48  : int := 0x1_0000_0000_0000;
-  const TWO_56  : int := 0x1_0000_0000_0000_00;
-  const TWO_63  : int := 0x0_8000_0000_0000_0000;
-  const TWO_64  : int := 0x1_0000_0000_0000_0000;
-  const TWO_127 : int := 0x0_8000_0000_0000_0000_0000_0000_0000_0000;
-  const TWO_128 : int := 0x1_0000_0000_0000_0000_0000_0000_0000_0000;
-  const TWO_160 : int := 0x1_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000;
-  const TWO_255 : int := 0x0_8000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000;
-  const TWO_256 : int := 0x1_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000;
+    // Powers of Two
+    const TWO_7   : int := 0x0_80;
+    const TWO_8   : int := 0x1_00;
+    const TWO_15  : int := 0x0_8000;
+    const TWO_16  : int := 0x1_0000;
+    const TWO_24  : int := 0x1_0000_00;
+    const TWO_31  : int := 0x0_8000_0000;
+    const TWO_32  : int := 0x1_0000_0000;
+    const TWO_40  : int := 0x1_0000_0000_00;
+    const TWO_48  : int := 0x1_0000_0000_0000;
+    const TWO_56  : int := 0x1_0000_0000_0000_00;
+    const TWO_63  : int := 0x0_8000_0000_0000_0000;
+    const TWO_64  : int := 0x1_0000_0000_0000_0000;
+    const TWO_127 : int := 0x0_8000_0000_0000_0000_0000_0000_0000_0000;
+    const TWO_128 : int := 0x1_0000_0000_0000_0000_0000_0000_0000_0000;
+    const TWO_160 : int := 0x1_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000;
+    const TWO_255 : int := 0x0_8000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000;
+    const TWO_256 : int := 0x1_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000;
 
-  // Signed Integers
-  const MIN_I8   : int := -TWO_7;
-  const MAX_I8   : int :=  TWO_7 - 1;
-  const MIN_I16  : int := -TWO_15;
-  const MAX_I16  : int :=  TWO_15 - 1;
-  const MIN_I32  : int := -TWO_31;
-  const MAX_I32  : int :=  TWO_31 - 1;
-  const MIN_I64  : int := -TWO_63;
-  const MAX_I64  : int :=  TWO_63 - 1;
-  const MIN_I128 : int := -TWO_127;
-  const MAX_I128 : int :=  TWO_127 - 1;
-  const MIN_I256 : int := -TWO_255;
-  const MAX_I256 : int :=  TWO_255 - 1;
+    // Signed Integers
+    const MIN_I8   : int := -TWO_7;
+    const MAX_I8   : int :=  TWO_7 - 1;
+    const MIN_I16  : int := -TWO_15;
+    const MAX_I16  : int :=  TWO_15 - 1;
+    const MIN_I32  : int := -TWO_31;
+    const MAX_I32  : int :=  TWO_31 - 1;
+    const MIN_I64  : int := -TWO_63;
+    const MAX_I64  : int :=  TWO_63 - 1;
+    const MIN_I128 : int := -TWO_127;
+    const MAX_I128 : int :=  TWO_127 - 1;
+    const MIN_I256 : int := -TWO_255;
+    const MAX_I256 : int :=  TWO_255 - 1;
 
-  newtype{:nativeType "sbyte"} i8 = i:int   | MIN_I8 <= i <= MAX_I8
-  newtype{:nativeType "short"} i16 = i:int  | MIN_I16 <= i <= MAX_I16
-  newtype{:nativeType "int"}   i32 = i:int  | MIN_I32 <= i <= MAX_I32
-  newtype{:nativeType "long"}  i64 = i:int  | MIN_I64 <= i <= MAX_I64
-  newtype i128 = i:int | MIN_I128 <= i <= MAX_I128
-  newtype i256 = i:int | MIN_I256 <= i <= MAX_I256
+    newtype{:nativeType "sbyte"} i8 = i:int   | MIN_I8 <= i <= MAX_I8
+    newtype{:nativeType "short"} i16 = i:int  | MIN_I16 <= i <= MAX_I16
+    newtype{:nativeType "int"}   i32 = i:int  | MIN_I32 <= i <= MAX_I32
+    newtype{:nativeType "long"}  i64 = i:int  | MIN_I64 <= i <= MAX_I64
+    newtype i128 = i:int | MIN_I128 <= i <= MAX_I128
+    newtype i256 = i:int | MIN_I256 <= i <= MAX_I256
 
-  // Unsigned Integers
-  const MAX_U8 : int :=  TWO_8 - 1;
-  const MAX_U16 : int := TWO_16 - 1;
-  const MAX_U24 : int := TWO_24 - 1;
-  const MAX_U32 : int := TWO_32 - 1;
-  const MAX_U40 : int := TWO_40 - 1;
-  const MAX_U48 : int := TWO_48 - 1;
-  const MAX_U56 : int := TWO_56 - 1;
-  const MAX_U64 : int := TWO_64 - 1;
-  const MAX_U128 : int := TWO_128 - 1;
-  const MAX_U160: int := TWO_160 - 1;
-  const MAX_U256: int := TWO_256 - 1
+    // Unsigned Integers
+    const MAX_U8 : int :=  TWO_8 - 1;
+    const MAX_U16 : int := TWO_16 - 1;
+    const MAX_U24 : int := TWO_24 - 1;
+    const MAX_U32 : int := TWO_32 - 1;
+    const MAX_U40 : int := TWO_40 - 1;
+    const MAX_U48 : int := TWO_48 - 1;
+    const MAX_U56 : int := TWO_56 - 1;
+    const MAX_U64 : int := TWO_64 - 1;
+    const MAX_U128 : int := TWO_128 - 1;
+    const MAX_U160: int := TWO_160 - 1;
+    const MAX_U256: int := TWO_256 - 1
 
-  newtype{:nativeType "byte"} u8 = i:int    | 0 <= i <= MAX_U8
-  newtype{:nativeType "ushort"} u16 = i:int | 0 <= i <= MAX_U16
-  newtype{:nativeType "uint"} u24 = i:int | 0 <= i <= MAX_U24
-  newtype{:nativeType "uint"} u32 = i:int   | 0 <= i <= MAX_U32
-  newtype{:nativeType "ulong"} u40 = i:int   | 0 <= i <= MAX_U40
-  newtype{:nativeType "ulong"} u48 = i:int   | 0 <= i <= MAX_U48
-  newtype{:nativeType "ulong"} u56 = i:int   | 0 <= i <= MAX_U56
-  newtype{:nativeType "ulong"} u64 = i:int  | 0 <= i <= MAX_U64
-  newtype u128 = i:int | 0 <= i <= MAX_U128
-  newtype u160 = i:int | 0 <= i <= MAX_U160
-  newtype u256 = i:int | 0 <= i <= MAX_U256
+    newtype{:nativeType "byte"} u8 = i:int    | 0 <= i <= MAX_U8
+    newtype{:nativeType "ushort"} u16 = i:int | 0 <= i <= MAX_U16
+    newtype{:nativeType "uint"} u24 = i:int | 0 <= i <= MAX_U24
+    newtype{:nativeType "uint"} u32 = i:int   | 0 <= i <= MAX_U32
+    newtype{:nativeType "ulong"} u40 = i:int   | 0 <= i <= MAX_U40
+    newtype{:nativeType "ulong"} u48 = i:int   | 0 <= i <= MAX_U48
+    newtype{:nativeType "ulong"} u56 = i:int   | 0 <= i <= MAX_U56
+    newtype{:nativeType "ulong"} u64 = i:int  | 0 <= i <= MAX_U64
+    newtype u128 = i:int | 0 <= i <= MAX_U128
+    newtype u160 = i:int | 0 <= i <= MAX_U160
+    newtype u256 = i:int | 0 <= i <= MAX_U256
 
 
-  // Determine maximum of two u256 integers.
-  function method Max(i1: int, i2: int) : int {
-    if i1 >= i2 then i1 else i2
-  }
+    // Determine maximum of two u256 integers.
+    function method Max(i1: int, i2: int) : int {
+        if i1 >= i2 then i1 else i2
+    }
 
-  // Round up a given number (i) by a given multiple (r).
-  function method RoundUp(i: int, r: nat) : int
-  requires r > 0 {
-    if (i % r) == 0 then i
-    else
-      ((i/r)*r) + r
-  }
+    // Round up a given number (i) by a given multiple (r).
+    function method RoundUp(i: int, r: nat) : int
+    requires r > 0 {
+        if (i % r) == 0 then i
+        else
+        ((i/r)*r) + r
+    }
 
-  // =========================================================
-  // Conversion to/from byte sequences
-  // =========================================================
+    // =========================================================
+    // Conversion to/from byte sequences
+    // =========================================================
 
-  function method ReadUint8(bytes: seq<u8>, address:nat) : u8
-  requires address < |bytes| {
-    bytes[address]
-  }
+    function method ReadUint8(bytes: seq<u8>, address:nat) : u8
+    requires address < |bytes| {
+        bytes[address]
+    }
 
-  function method ReadUint16(bytes: seq<u8>, address:nat) : u16
-  requires (address+1) < |bytes| {
-    var b1 := bytes[address] as u16;
-    var b2 := bytes[address+1] as u16;
-    (b1 * (TWO_8 as u16)) + b2
-  }
+    function method ReadUint16(bytes: seq<u8>, address:nat) : u16
+    requires (address+1) < |bytes| {
+        var b1 := bytes[address] as u16;
+        var b2 := bytes[address+1] as u16;
+        (b1 * (TWO_8 as u16)) + b2
+    }
 
-  function method ReadUint32(bytes: seq<u8>, address:nat) : u32
-  requires (address+3) < |bytes| {
-    var b1 := ReadUint16(bytes, address) as u32;
-    var b2 := ReadUint16(bytes, address+2) as u32;
-    (b1 * (TWO_16 as u32)) + b2
-  }
+    function method ReadUint32(bytes: seq<u8>, address:nat) : u32
+    requires (address+3) < |bytes| {
+        var b1 := ReadUint16(bytes, address) as u32;
+        var b2 := ReadUint16(bytes, address+2) as u32;
+        (b1 * (TWO_16 as u32)) + b2
+    }
 
-  function method ReadUint64(bytes: seq<u8>, address:nat) : u64
-  requires (address+7) < |bytes| {
-    var b1 := ReadUint32(bytes, address) as u64;
-    var b2 := ReadUint32(bytes, address+4) as u64;
-    (b1 * (TWO_32 as u64)) + b2
-  }
+    function method ReadUint64(bytes: seq<u8>, address:nat) : u64
+    requires (address+7) < |bytes| {
+        var b1 := ReadUint32(bytes, address) as u64;
+        var b2 := ReadUint32(bytes, address+4) as u64;
+        (b1 * (TWO_32 as u64)) + b2
+    }
 
-  // =========================================================
-  // Exponent
-  // =========================================================
+    // =========================================================
+    // Exponent
+    // =========================================================
 
     /**
      * Compute n^k.
      */
-    function method Pow(n:nat, k:nat) : int {
+    function method Pow(n:nat, k:nat) : nat {
         if k == 0 then 1
         else if k == 1 then n
         else
@@ -138,300 +138,353 @@ module Int {
             else np * np * n
     }
 
-  // Various sanity tests for exponentiation.
-  method PowTests() {
-    assert Pow(2,8) == TWO_8;
-    assert Pow(2,15) == TWO_15;
-    assert Pow(2,16) == TWO_16;
-    assert Pow(2,24) == TWO_24;
-    assert Pow(2,31) == TWO_31;
-    assert Pow(2,32) == TWO_32;
-    assert Pow(2,40) == TWO_40;
-    assert Pow(2,48) == TWO_48;
-    assert Pow(2,56) == TWO_56;
-    assert Pow(2,63) == TWO_63;
-    assert Pow(2,64) == TWO_64;
-    // NOTE:  I have to break the following ones up because Z3
-    // cannot handle it.
-    assert Pow(2,63) * Pow(2,64) == TWO_127;
-    assert Pow(2,64) * Pow(2,64) == TWO_128;
-    assert Pow(2,64) * Pow(2,64) * Pow(2,64) * Pow(2,64) == TWO_256;
-    assert (TWO_128 / TWO_64) == TWO_64;
-    assert (TWO_256 / TWO_128) == TWO_128;
-  }
+    // Simple lemma about POW.
+    lemma lemma_pow2(k:nat)
+    ensures Pow(2,k) > 0 {
+        if k == 0 {
+            assert Pow(2,k) == 1;
+        } else if k == 1 {
+            assert Pow(2,k) == 2;
+        } else {
+            lemma_pow2(k/2);
+        }
+    }
 
-  // =========================================================
-  // Non-Euclidean Division / Remainder
-  // =========================================================
+    // Various sanity tests for exponentiation.
+    method PowTests() {
+        assert Pow(2,8) == TWO_8;
+        assert Pow(2,15) == TWO_15;
+        assert Pow(2,16) == TWO_16;
+        assert Pow(2,24) == TWO_24;
+        assert Pow(2,31) == TWO_31;
+        assert Pow(2,32) == TWO_32;
+        assert Pow(2,40) == TWO_40;
+        assert Pow(2,48) == TWO_48;
+        assert Pow(2,56) == TWO_56;
+        assert Pow(2,63) == TWO_63;
+        assert Pow(2,64) == TWO_64;
+        // NOTE:  I have to break the following ones up because Z3
+        // cannot handle it.
+        assert Pow(2,63) * Pow(2,64) == TWO_127;
+        assert Pow(2,64) * Pow(2,64) == TWO_128;
+        assert Pow(2,64) * Pow(2,64) * Pow(2,64) * Pow(2,64) == TWO_256;
+        assert (TWO_128 / TWO_64) == TWO_64;
+        assert (TWO_256 / TWO_128) == TWO_128;
+    }
 
-  // This provides a non-Euclidean division operator and is necessary
-  // because Dafny (unlike just about every other programming
-  // language) supports Euclidean division.  This operator, therefore,
-  // always divides *towards* zero.
-  function method Div(lhs: int, rhs: int) : int
-  requires rhs != 0 {
-    if lhs >= 0 then lhs / rhs
-    else
-      -((-lhs) / rhs)
-  }
+    // =========================================================
+    // Non-Euclidean Division / Remainder
+    // =========================================================
 
-  // This provides a non-Euclidean Remainder operator and is necessary
-  // because Dafny (unlike just about every other programming
-  // language) supports Euclidean division.  Observe that this is a
-  // true Remainder operator, and not a modulus operator.  For
-  // emxaple, this means the result can be negative.
-  function method Rem(lhs: int, rhs: int) : int
-  requires rhs != 0 {
-    if lhs >= 0 then (lhs % rhs)
-    else
-      var d := -((-lhs) / rhs);
-      lhs - (d * rhs)
-  }
+    // This provides a non-Euclidean division operator and is necessary
+    // because Dafny (unlike just about every other programming
+    // language) supports Euclidean division.  This operator, therefore,
+    // always divides *towards* zero.
+    function method Div(lhs: int, rhs: int) : int
+    requires rhs != 0 {
+        if lhs >= 0 then lhs / rhs
+        else
+        -((-lhs) / rhs)
+    }
 
-  // Various sanity tests for division.
-  method DivTests() {
-    // pos-pos
-    assert Div(6,2) == 3;
-    assert Div(6,3) == 2;
-    assert Div(6,4) == 1;
-    assert Div(9,4) == 2;
-    // neg-pos
-    assert Div(-6,2) == -3;
-    assert Div(-6,3) == -2;
-    assert Div(-6,4) == -1;
-    assert Div(-9,4) == -2;
-    // pos-neg
-    assert Div(6,-2) == -3;
-    assert Div(6,-3) == -2;
-    assert Div(6,-4) == -1;
-    assert Div(9,-4) == -2;
-    // neg-neg
-    assert Div(-6,-2) == 3;
-    assert Div(-6,-3) == 2;
-    assert Div(-6,-4) == 1;
-    assert Div(-9,-4) == 2;
-  }
+    // This provides a non-Euclidean Remainder operator and is necessary
+    // because Dafny (unlike just about every other programming
+    // language) supports Euclidean division.  Observe that this is a
+    // true Remainder operator, and not a modulus operator.  For
+    // emxaple, this means the result can be negative.
+    function method Rem(lhs: int, rhs: int) : int
+    requires rhs != 0 {
+        if lhs >= 0 then (lhs % rhs)
+        else
+        var d := -((-lhs) / rhs);
+        lhs - (d * rhs)
+    }
 
-  // Various sanity tests for Remainder.
-  method RemTests() {
-    // pos-pos
-    assert Rem(6,2) == 0;
-    assert Rem(6,3) == 0;
-    assert Rem(6,4) == 2;
-    assert Rem(9,4) == 1;
-    // neg-pos
-    assert Rem(-6,2) == 0;
-    assert Rem(-6,3) == 0;
-    assert Rem(-6,4) == -2;
-    assert Rem(-9,4) == -1;
-    // pos-neg
-    assert Rem(6,-2) == 0;
-    assert Rem(6,-3) == 0;
-    assert Rem(6,-4) == 2;
-    assert Rem(9,-4) == 1;
-    // neg-neg
-    assert Rem(-6,-2) == 0;
-    assert Rem(-6,-3) == 0;
-    assert Rem(-6,-4) == -2;
-    assert Rem(-9,-4) == -1;
-  }
-}
+    // Various sanity tests for division.
+    method DivTests() {
+        // pos-pos
+        assert Div(6,2) == 3;
+        assert Div(6,3) == 2;
+        assert Div(6,4) == 1;
+        assert Div(9,4) == 2;
+        // neg-pos
+        assert Div(-6,2) == -3;
+        assert Div(-6,3) == -2;
+        assert Div(-6,4) == -1;
+        assert Div(-9,4) == -2;
+        // pos-neg
+        assert Div(6,-2) == -3;
+        assert Div(6,-3) == -2;
+        assert Div(6,-4) == -1;
+        assert Div(9,-4) == -2;
+        // neg-neg
+        assert Div(-6,-2) == 3;
+        assert Div(-6,-3) == 2;
+        assert Div(-6,-4) == 1;
+        assert Div(-9,-4) == 2;
+    }
+
+    // Various sanity tests for Remainder.
+    method RemTests() {
+        // pos-pos
+        assert Rem(6,2) == 0;
+        assert Rem(6,3) == 0;
+        assert Rem(6,4) == 2;
+        assert Rem(9,4) == 1;
+        // neg-pos
+        assert Rem(-6,2) == 0;
+        assert Rem(-6,3) == 0;
+        assert Rem(-6,4) == -2;
+        assert Rem(-9,4) == -1;
+        // pos-neg
+        assert Rem(6,-2) == 0;
+        assert Rem(6,-3) == 0;
+        assert Rem(6,-4) == 2;
+        assert Rem(9,-4) == 1;
+        // neg-neg
+        assert Rem(-6,-2) == 0;
+        assert Rem(-6,-3) == 0;
+        assert Rem(-6,-4) == -2;
+        assert Rem(-9,-4) == -1;
+    }
+    }
 
 /**
  * Various helper methods related to unsigned 16bit integers.
  */
 module U16 {
-  import opened Int
+    import opened Int
 
-  // Read nth 8bit word (i.e. byte) out of this u16, where 0
-  // identifies the most significant byte.
-  function method NthUint8(v:u16, k: nat) : u8
-    // Cannot read more than two words!
-  requires k < 2 {
-    if k == 0
-        then (v / (TWO_8 as u16)) as u8
-      else
-        (v % (TWO_8 as u16)) as u8
-  }
+    // Read nth 8bit word (i.e. byte) out of this u16, where 0
+    // identifies the most significant byte.
+    function method NthUint8(v:u16, k: nat) : u8
+        // Cannot read more than two words!
+    requires k < 2 {
+        if k == 0
+            then (v / (TWO_8 as u16)) as u8
+        else
+            (v % (TWO_8 as u16)) as u8
+    }
 
-  method tests_NthUint8() {
-    assert NthUint8(0xde80,0) == 0xde;
-    assert NthUint8(0xde80,1) == 0x80;
-  }
+    method tests_NthUint8() {
+        assert NthUint8(0xde80,0) == 0xde;
+        assert NthUint8(0xde80,1) == 0x80;
+    }
 }
 
 /**
  * Various helper methods related to unsigned 32bit integers.
  */
 module U32 {
-  import opened Int
+    import opened Int
 
-  // Read nth 16bit word out of this u32, where 0 identifies the most
-  // significant word.
-  function method NthUint16(v:u32, k: nat) : u16
-    // Cannot read more than two words!
-  requires k < 2 {
-    if k == 0
-        then (v / (TWO_16 as u32)) as u16
-      else
-        (v % (TWO_16 as u32)) as u16
-  }
+    // Read nth 16bit word out of this u32, where 0 identifies the most
+    // significant word.
+    function method NthUint16(v:u32, k: nat) : u16
+        // Cannot read more than two words!
+    requires k < 2 {
+        if k == 0
+            then (v / (TWO_16 as u32)) as u16
+        else
+            (v % (TWO_16 as u32)) as u16
+    }
 
-  method tests_Nth_u16() {
-    assert NthUint16(0x1230de80,0) == 0x1230;
-    assert NthUint16(0x1230de80,1) == 0xde80;
-  }
+    method tests_Nth_u16() {
+        assert NthUint16(0x1230de80,0) == 0x1230;
+        assert NthUint16(0x1230de80,1) == 0xde80;
+    }
 }
 
 /**
  * Various helper methods related to unsigned 64bit integers.
  */
 module U64 {
-  import opened Int
+    import opened Int
 
-  // Read nth 32bit word out of this u64, where 0 identifies the most
-  // significant word.
-  function method NthUint32(v:u64, k: nat) : u32
-    // Cannot read more than two words!
-  requires k < 2 {
-    if k == 0
-        then (v / (TWO_32 as u64)) as u32
-      else
-        (v % (TWO_32 as u64)) as u32
-  }
+    // Read nth 32bit word out of this u64, where 0 identifies the most
+    // significant word.
+    function method NthUint32(v:u64, k: nat) : u32
+        // Cannot read more than two words!
+    requires k < 2 {
+        if k == 0
+            then (v / (TWO_32 as u64)) as u32
+        else
+            (v % (TWO_32 as u64)) as u32
+    }
 
-  method testsNthUint32() {
-    assert NthUint32(0x00112233_44556677,0) == 0x00112233;
-    assert NthUint32(0x00112233_44556677,1) == 0x44556677;
-  }
+    method testsNthUint32() {
+        assert NthUint32(0x00112233_44556677,0) == 0x00112233;
+        assert NthUint32(0x00112233_44556677,1) == 0x44556677;
+    }
 }
 
 /**
  * Various helper methods related to unsigned 128bit integers.
  */
 module U128 {
-  import opened Int
+    import opened Int
 
-  // Read nth 64bit word out of this u128, where 0 identifies the most
-  // significant word.
-  function method NthUint64(v:u128, k: nat) : u64
-    // Cannot read more than two words!
-  requires k < 2 {
-    if k == 0
-        then (v / (TWO_64 as u128)) as u64
-      else
-        (v % (TWO_64 as u128)) as u64
-  }
+    // Read nth 64bit word out of this u128, where 0 identifies the most
+    // significant word.
+    function method NthUint64(v:u128, k: nat) : u64
+        // Cannot read more than two words!
+    requires k < 2 {
+        if k == 0
+            then (v / (TWO_64 as u128)) as u64
+        else
+            (v % (TWO_64 as u128)) as u64
+    }
 
-  method testsNthUint64() {
-    assert NthUint64(0x0011223344556677_8899AABBCCDDEEFF,0) == 0x0011223344556677;
-    assert NthUint64(0x0011223344556677_8899AABBCCDDEEFF,1) == 0x8899AABBCCDDEEFF;
-  }
+    method testsNthUint64() {
+        assert NthUint64(0x0011223344556677_8899AABBCCDDEEFF,0) == 0x0011223344556677;
+        assert NthUint64(0x0011223344556677_8899AABBCCDDEEFF,1) == 0x8899AABBCCDDEEFF;
+    }
 }
 
 /**
  * Various helper methods related to unsigned 256bit integers.
  */
 module U256 {
-  import opened Int
-  import U128
-  import U64
-  import U32
-  import U16
+    import opened Int
+    import U128
+    import U64
+    import U32
+    import U16
 
-  // Read nth 128bit word out of this u256, where 0 identifies the most
-  // significant word.
-  function method NthUint128(v:u256, k: nat) : u128
-    // Cannot read more than two words!
-    requires k < 2 {
-      if k == 0
-        then (v / (TWO_128 as u256)) as u128
-      else
-        (v % (TWO_128 as u256)) as u128
-  }
+    function method Shl(lhs: u256, rhs: u256) : u256 {
+        var lbv := lhs as bv256;
+        // NOTE: unclear whether shifting is optimal choice here.
+        var res := if rhs < 256 then (lbv << rhs) else 0;
+        //
+        res as u256
+    }
 
-  // Read nth byte out of this u256, where 0 identifies the most
-  // significant byte.
-  function method NthUint8(v:u256, k: nat) : u8
-    // Cannot read more than 32bytes!
-    requires k < 32 {
-      // This is perhaps a tad ugly.  Happy to take suggestions on
-      // a better approach :)
-      var w128 := NthUint128(v,k / 16);
-      var w64 := U128.NthUint64(w128,(k % 16) / 8);
-      var w32 :=  U64.NthUint32(w64,(k % 8) / 4);
-      var w16 :=  U32.NthUint16(w32,(k % 4) / 2);
-      U16.NthUint8(w16,k%2)
-  }
+    function method Shr(lhs: u256, rhs: u256) : u256 {
+        var lbv := lhs as bv256;
+        // NOTE: unclear whether shifting is optimal choice here.
+        var res := if rhs < 256 then (lbv >> rhs) else 0;
+        //
+        res as u256
+    }
 
-  method testsNthUint128() {
-    assert NthUint128(0x00112233445566778899AABBCCDDEEFF_FFEEDDCCBBAA99887766554433221100,0) == 0x00112233445566778899AABBCCDDEEFF;
-    assert NthUint128(0x00112233445566778899AABBCCDDEEFF_FFEEDDCCBBAA99887766554433221100,1) == 0xFFEEDDCCBBAA99887766554433221100;
-  }
+    // Read nth 128bit word out of this u256, where 0 identifies the most
+    // significant word.
+    function method NthUint128(v:u256, k: nat) : u128
+        // Cannot read more than two words!
+        requires k < 2 {
+        if k == 0
+            then (v / (TWO_128 as u256)) as u128
+        else
+            (v % (TWO_128 as u256)) as u128
+    }
 
-  method testsNthUint8() {
-    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,00) == 0x00;
-    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,01) == 0x01;
-    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,02) == 0x02;
-    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,03) == 0x03;
-    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,04) == 0x04;
-    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,05) == 0x05;
-    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,06) == 0x06;
-    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,07) == 0x07;
-    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,08) == 0x08;
-    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,09) == 0x09;
-    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,10) == 0x0A;
-    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,11) == 0x0B;
-    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,12) == 0x0C;
-    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,13) == 0x0D;
-    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,14) == 0x0E;
-    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,15) == 0x0F;
-    //
-    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,16) == 0x10;
-    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,17) == 0x11;
-    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,18) == 0x12;
-    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,19) == 0x13;
-    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,20) == 0x14;
-    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,21) == 0x15;
-    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,22) == 0x16;
-    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,23) == 0x17;
-    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,24) == 0x18;
-    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,25) == 0x19;
-    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,26) == 0x1A;
-    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,27) == 0x1B;
-    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,28) == 0x1C;
-    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,29) == 0x1D;
-    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,30) == 0x1E;
-    assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,31) == 0x1F;
+    // Read nth byte out of this u256, where 0 identifies the most
+    // significant byte.
+    function method NthUint8(v:u256, k: nat) : u8
+        // Cannot read more than 32bytes!
+        requires k < 32 {
+        // This is perhaps a tad ugly.  Happy to take suggestions on
+        // a better approach :)
+        var w128 := NthUint128(v,k / 16);
+        var w64 := U128.NthUint64(w128,(k % 16) / 8);
+        var w32 :=  U64.NthUint32(w64,(k % 8) / 4);
+        var w16 :=  U32.NthUint16(w32,(k % 4) / 2);
+        U16.NthUint8(w16,k%2)
+    }
 
-  }
+    method testsNthUint128() {
+        assert NthUint128(0x00112233445566778899AABBCCDDEEFF_FFEEDDCCBBAA99887766554433221100,0) == 0x00112233445566778899AABBCCDDEEFF;
+        assert NthUint128(0x00112233445566778899AABBCCDDEEFF_FFEEDDCCBBAA99887766554433221100,1) == 0xFFEEDDCCBBAA99887766554433221100;
+    }
+
+    method testsNthUint8() {
+        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,00) == 0x00;
+        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,01) == 0x01;
+        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,02) == 0x02;
+        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,03) == 0x03;
+        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,04) == 0x04;
+        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,05) == 0x05;
+        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,06) == 0x06;
+        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,07) == 0x07;
+        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,08) == 0x08;
+        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,09) == 0x09;
+        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,10) == 0x0A;
+        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,11) == 0x0B;
+        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,12) == 0x0C;
+        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,13) == 0x0D;
+        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,14) == 0x0E;
+        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,15) == 0x0F;
+        //
+        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,16) == 0x10;
+        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,17) == 0x11;
+        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,18) == 0x12;
+        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,19) == 0x13;
+        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,20) == 0x14;
+        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,21) == 0x15;
+        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,22) == 0x16;
+        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,23) == 0x17;
+        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,24) == 0x18;
+        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,25) == 0x19;
+        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,26) == 0x1A;
+        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,27) == 0x1B;
+        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,28) == 0x1C;
+        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,29) == 0x1D;
+        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,30) == 0x1E;
+        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,31) == 0x1F;
+
+    }
 }
 
 module I256 {
-  import opened Int
+    import U256
+    import Word
+    import opened Int
 
-  // This provides a non-Euclidean division operator and is necessary
-  // because Dafny (unlike just about every other programming
-  // language) supports Euclidean division.  This operator, therefore,
-  // always divides *towards* zero.
-  function method div(lhs: i256, rhs: i256) : i256
-    // Cannot divide by zero!
-    requires rhs != 0
-    // Range restriction to prevent overflow
-    requires (rhs != -1 || lhs != (-TWO_255 as i256)) {
-    Int.Div(lhs as int, rhs as int) as i256
-  }
+    // This provides a non-Euclidean division operator and is necessary
+    // because Dafny (unlike just about every other programming
+    // language) supports Euclidean division.  This operator, therefore,
+    // always divides *towards* zero.
+    function method div(lhs: i256, rhs: i256) : i256
+        // Cannot divide by zero!
+        requires rhs != 0
+        // Range restriction to prevent overflow
+        requires (rhs != -1 || lhs != (-TWO_255 as i256)) {
+        Int.Div(lhs as int, rhs as int) as i256
+    }
 
-  // This provides a non-Euclidean Remainder operator and is necessary
-  // because Dafny (unlike just about every other programming
-  // language) supports Euclidean division.  Observe that this is a
-  // true Remainder operator, and not a modulus operator.  For
-  // emxaple, this means the result can be negative.
-  function method Rem(lhs: i256, rhs: i256) : i256
-    // Cannot divide by zero!
-    requires rhs != 0 {
-    Int.Rem(lhs as int, rhs as int) as i256
-  }
+    // This provides a non-Euclidean Remainder operator and is necessary
+    // because Dafny (unlike just about every other programming
+    // language) supports Euclidean division.  Observe that this is a
+    // true Remainder operator, and not a modulus operator.  For
+    // emxaple, this means the result can be negative.
+    function method Rem(lhs: i256, rhs: i256) : i256
+        // Cannot divide by zero!
+        requires rhs != 0 {
+        Int.Rem(lhs as int, rhs as int) as i256
+    }
+
+    // Shift Arithmetic Right using Bitshifts
+    function method Sar(lhs: i256, rhs: u256) : u256 {
+        if lhs >= 0 then
+            // Easy case, unsigned shr sufficient.
+            U256.Shr(lhs as u256, rhs)
+        else if rhs > 256 then MAX_U256 as u256
+        else
+            // Determine mask
+            var mask := (MAX_U256 as bv256) << (256 - rhs);
+            var lbv := (Word.fromI256(lhs) as bv256 >> rhs);
+            (mask | lbv) as u256
+    }
+
+    // Shift Arithmetic Right.  This implementation follows the Yellow Paper quite
+    // accurately.  However, it performs very poorly when translated into Java.
+    function method Sar2(lhs: i256, rhs: u256) : i256 {
+        if rhs == 0 then lhs
+        else
+            var r := Int.Pow(2,rhs as nat);
+            lemma_pow2(rhs as nat);
+            ((lhs as int) / r) as i256
+    }
 }
 
 module Word {

--- a/src/test/java/dafnyevm/Tests.java
+++ b/src/test/java/dafnyevm/Tests.java
@@ -14,6 +14,7 @@
 package dafnyevm;
 import java.math.BigInteger;
 import java.util.HashMap;
+import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
 
@@ -744,7 +745,61 @@ public class Tests {
 		assertArrayEquals(UINT256(0x7F0), output);
 	}
 
-	// Add more shift tests here!
+	@Test
+	public void test_shr_01() {
+		// 0x1FC >> 1 = 0xFE
+		byte[] output = call(new int[] { PUSH2, 0x1, 0xFC, PUSH1, 0x1, SHR, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
+		assertArrayEquals(UINT256(0xFE), output);
+	}
+
+	@Test
+	public void test_shr_02() {
+		// 0x3F8 >> 2 = 0xFE
+		byte[] output = call(new int[] { PUSH2, 0x3, 0xF8, PUSH1, 0x2, SHR, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
+		assertArrayEquals(UINT256(0xFE), output);
+	}
+
+	@Test
+	public void test_shr_03() {
+		// 0x7F0 >> 3 = 0xFE
+		byte[] output = call(new int[] { PUSH2, 0x7, 0xF0, PUSH1, 0x3, SHR, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
+		assertArrayEquals(UINT256(0xFE), output);
+	}
+
+	@Test
+	public void test_sar_01() {
+		// (0 - 0x2) >> 1 = -0x1
+		byte[] output = call(new int[] { PUSH1, 0x2, PUSH1, 0x0, SUB, PUSH1, 0x1, SAR, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
+		assertArrayEquals(INT256(-0x1), output);
+	}
+
+	@Test
+	public void test_sar_02() {
+		// 0x1FC >> 1 = 0xFE
+		byte[] output = call(new int[] { PUSH2, 0x1, 0xFC, PUSH1, 0x1, SAR, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
+		assertArrayEquals(UINT256(0xFE), output);
+	}
+
+	@Test
+	public void test_sar_03() {
+		// (0 - 0x1FC) >> 1 = -0xFE
+		byte[] output = call(new int[] { PUSH2, 0x1, 0xFC, PUSH1, 0x0, SUB, PUSH1, 0x1, SAR, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
+		assertArrayEquals(INT256(-0xFE), output);
+	}
+
+	@Test
+	public void test_sar_04() {
+		// (0 - 0x3F8) >> 2 = -0xFE
+		byte[] output = call(new int[] { PUSH2, 0x3, 0xF8, PUSH1, 0x0, SUB, PUSH1, 0x2, SAR, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
+		assertArrayEquals(INT256(-0xFE), output);
+	}
+
+	@Test
+	public void test_sar_05() {
+		// (0 - 0x7F0) >> 3 = -0xFE
+		byte[] output = call(new int[] { PUSH2, 0x7, 0xF0, PUSH1, 0x0, SUB, PUSH1, 0x3, SAR, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
+		assertArrayEquals(INT256(-0xFE), output);
+	}
 
 	// ========================================================================
 	// LT / GT / SLT / SGT / EQ / ISZERO
@@ -1575,6 +1630,25 @@ public class Tests {
 		bytes[29] = (byte) ((x >> 16) & 0xFF);
 		bytes[28] = (byte) ((x >> 24) & 0xFF);
 		return bytes;
+	}
+
+	/**
+	 * Construct a 256bit representation (in big endian form) of a signed Java int.
+	 * @param x
+	 * @return
+	 */
+	private byte[] INT256(int x) {
+		if (x >= 0) {
+			return UINT256(x);
+		} else {
+			byte[] bytes = new byte[32];
+			Arrays.fill(bytes, 0, 31, (byte) 0xff);
+			bytes[31] = (byte) (x & 0xFF);
+			bytes[30] = (byte) ((x >> 8) & 0xFF);
+			bytes[29] = (byte) ((x >> 16) & 0xFF);
+			bytes[28] = (byte) ((x >> 24) & 0xFF);
+			return bytes;
+		}
 	}
 
 	/**


### PR DESCRIPTION
This puts through two implementations of the SAR bytecode.  One follows
the yellow paper, whilst the other uses bitshifts.  The latter appears
to perform significantly better when translated into Java.