### PR TITLE
Move tests into tests/dafny #137

### DIFF
--- a/src/dafny/util/bytes.dfy
+++ b/src/dafny/util/bytes.dfy
@@ -113,14 +113,4 @@ module Bytes {
     // Append it!
     Padding(k) + bytes
   }
-
-  /* this causes problems for me when running F5; the error encountered is "Xunit Namespace Could not be Found in Visual Studio Code" */
-  /*
-  method {:test} LeftPadTests() {
-    assert LeftPad([0],2) == [0,0];
-    assert LeftPad([1],2) == [0,1];
-    assert LeftPad([1],4) == [0,0,0,1];
-    assert LeftPad([1,2],4) == [0,0,1,2];
-  }
-  */
 }

--- a/src/dafny/util/int.dfy
+++ b/src/dafny/util/int.dfy
@@ -150,28 +150,6 @@ module Int {
         }
     }
 
-    // Various sanity tests for exponentiation.
-    method PowTests() {
-        assert Pow(2,8) == TWO_8;
-        assert Pow(2,15) == TWO_15;
-        assert Pow(2,16) == TWO_16;
-        assert Pow(2,24) == TWO_24;
-        assert Pow(2,31) == TWO_31;
-        assert Pow(2,32) == TWO_32;
-        assert Pow(2,40) == TWO_40;
-        assert Pow(2,48) == TWO_48;
-        assert Pow(2,56) == TWO_56;
-        assert Pow(2,63) == TWO_63;
-        assert Pow(2,64) == TWO_64;
-        // NOTE:  I have to break the following ones up because Z3
-        // cannot handle it.
-        assert Pow(2,63) * Pow(2,64) == TWO_127;
-        assert Pow(2,64) * Pow(2,64) == TWO_128;
-        assert Pow(2,64) * Pow(2,64) * Pow(2,64) * Pow(2,64) == TWO_256;
-        assert (TWO_128 / TWO_64) == TWO_64;
-        assert (TWO_256 / TWO_128) == TWO_128;
-    }
-
     // =========================================================
     // Non-Euclidean Division / Remainder
     // =========================================================
@@ -199,55 +177,7 @@ module Int {
         var d := -((-lhs) / rhs);
         lhs - (d * rhs)
     }
-
-    // Various sanity tests for division.
-    method DivTests() {
-        // pos-pos
-        assert Div(6,2) == 3;
-        assert Div(6,3) == 2;
-        assert Div(6,4) == 1;
-        assert Div(9,4) == 2;
-        // neg-pos
-        assert Div(-6,2) == -3;
-        assert Div(-6,3) == -2;
-        assert Div(-6,4) == -1;
-        assert Div(-9,4) == -2;
-        // pos-neg
-        assert Div(6,-2) == -3;
-        assert Div(6,-3) == -2;
-        assert Div(6,-4) == -1;
-        assert Div(9,-4) == -2;
-        // neg-neg
-        assert Div(-6,-2) == 3;
-        assert Div(-6,-3) == 2;
-        assert Div(-6,-4) == 1;
-        assert Div(-9,-4) == 2;
-    }
-
-    // Various sanity tests for Remainder.
-    method RemTests() {
-        // pos-pos
-        assert Rem(6,2) == 0;
-        assert Rem(6,3) == 0;
-        assert Rem(6,4) == 2;
-        assert Rem(9,4) == 1;
-        // neg-pos
-        assert Rem(-6,2) == 0;
-        assert Rem(-6,3) == 0;
-        assert Rem(-6,4) == -2;
-        assert Rem(-9,4) == -1;
-        // pos-neg
-        assert Rem(6,-2) == 0;
-        assert Rem(6,-3) == 0;
-        assert Rem(6,-4) == 2;
-        assert Rem(9,-4) == 1;
-        // neg-neg
-        assert Rem(-6,-2) == 0;
-        assert Rem(-6,-3) == 0;
-        assert Rem(-6,-4) == -2;
-        assert Rem(-9,-4) == -1;
-    }
-    }
+}
 
 /**
  * Various helper methods related to unsigned 16bit integers.
@@ -264,11 +194,6 @@ module U16 {
             then (v / (TWO_8 as u16)) as u8
         else
             (v % (TWO_8 as u16)) as u8
-    }
-
-    method tests_NthUint8() {
-        assert NthUint8(0xde80,0) == 0xde;
-        assert NthUint8(0xde80,1) == 0x80;
     }
 }
 
@@ -288,11 +213,6 @@ module U32 {
         else
             (v % (TWO_16 as u32)) as u16
     }
-
-    method tests_Nth_u16() {
-        assert NthUint16(0x1230de80,0) == 0x1230;
-        assert NthUint16(0x1230de80,1) == 0xde80;
-    }
 }
 
 /**
@@ -311,11 +231,6 @@ module U64 {
         else
             (v % (TWO_32 as u64)) as u32
     }
-
-    method testsNthUint32() {
-        assert NthUint32(0x00112233_44556677,0) == 0x00112233;
-        assert NthUint32(0x00112233_44556677,1) == 0x44556677;
-    }
 }
 
 /**
@@ -333,11 +248,6 @@ module U128 {
             then (v / (TWO_64 as u128)) as u64
         else
             (v % (TWO_64 as u128)) as u64
-    }
-
-    method testsNthUint64() {
-        assert NthUint64(0x0011223344556677_8899AABBCCDDEEFF,0) == 0x0011223344556677;
-        assert NthUint64(0x0011223344556677_8899AABBCCDDEEFF,1) == 0x8899AABBCCDDEEFF;
     }
 }
 
@@ -390,48 +300,6 @@ module U256 {
         var w32 :=  U64.NthUint32(w64,(k % 8) / 4);
         var w16 :=  U32.NthUint16(w32,(k % 4) / 2);
         U16.NthUint8(w16,k%2)
-    }
-
-    method testsNthUint128() {
-        assert NthUint128(0x00112233445566778899AABBCCDDEEFF_FFEEDDCCBBAA99887766554433221100,0) == 0x00112233445566778899AABBCCDDEEFF;
-        assert NthUint128(0x00112233445566778899AABBCCDDEEFF_FFEEDDCCBBAA99887766554433221100,1) == 0xFFEEDDCCBBAA99887766554433221100;
-    }
-
-    method testsNthUint8() {
-        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,00) == 0x00;
-        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,01) == 0x01;
-        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,02) == 0x02;
-        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,03) == 0x03;
-        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,04) == 0x04;
-        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,05) == 0x05;
-        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,06) == 0x06;
-        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,07) == 0x07;
-        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,08) == 0x08;
-        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,09) == 0x09;
-        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,10) == 0x0A;
-        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,11) == 0x0B;
-        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,12) == 0x0C;
-        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,13) == 0x0D;
-        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,14) == 0x0E;
-        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,15) == 0x0F;
-        //
-        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,16) == 0x10;
-        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,17) == 0x11;
-        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,18) == 0x12;
-        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,19) == 0x13;
-        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,20) == 0x14;
-        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,21) == 0x15;
-        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,22) == 0x16;
-        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,23) == 0x17;
-        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,24) == 0x18;
-        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,25) == 0x19;
-        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,26) == 0x1A;
-        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,27) == 0x1B;
-        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,28) == 0x1C;
-        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,29) == 0x1D;
-        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,30) == 0x1E;
-        assert NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,31) == 0x1F;
-
     }
 }
 
@@ -516,22 +384,5 @@ module Word {
       v as u256
     else
       w as u256
-  }
-
-  // =========================================================
-  // Sanity Checks
-  // =========================================================
-
-  method test() {
-    // ==>
-    assert asI256(0) == 0;
-    assert asI256(MAX_U256 as u256) == -1;
-    assert asI256(MAX_I256 as u256) == (MAX_I256 as i256);
-    assert asI256((MAX_I256 + 1) as u256) == (MIN_I256 as i256);
-    // <==
-    assert fromI256(0) == 0;
-    assert fromI256(-1) == (MAX_U256 as u256);
-    assert fromI256(MAX_I256 as i256) == (MAX_I256 as u256);
-    assert fromI256(MIN_I256 as i256) == (TWO_255 as u256);
   }
 }

--- a/src/test/dafny/ByteTests.dfy
+++ b/src/test/dafny/ByteTests.dfy
@@ -1,0 +1,86 @@
+include "../../dafny/util/bytes.dfy"
+
+import opened Bytes
+
+method {:test} ReadTests() {
+    // U8
+    assert ReadUint8([],0) == 0;
+    assert ReadUint8([0],0) == 0;
+    assert ReadUint8([1],0) == 1;
+    assert ReadUint8([1],1) == 0;
+    assert ReadUint8([1,2],0) == 1;
+    assert ReadUint8([1,2],1) == 2;
+    // U16
+    assert ReadUint16([],0) == 0;
+    assert ReadUint16([0],0) == 0;
+    assert ReadUint16([0],1) == 0;
+    assert ReadUint16([0,0],0) == 0;
+    assert ReadUint16([0,1],0) == 1;
+    assert ReadUint16([1,0],0) == 256;
+    assert ReadUint16([0xFF],0) == 0xFF00;
+    assert ReadUint16([0xFF,0],0) == 0xFF00;
+    assert ReadUint16([0xFF,1],0) == 0xFF01;
+    // U32
+    assert ReadUint32([],0) == 0;
+    assert ReadUint32([0],0) == 0;
+    assert ReadUint32([0xFF],0) == 0xFF00_0000;
+    assert ReadUint32([0,0xFF],0) == 0x00FF_0000;
+    assert ReadUint32([0,0xFF,0],0) == 0x00FF_0000;
+    assert ReadUint32([0,0xFF,0,0xD],0) == 0x00FF_000D;
+    assert ReadUint32([0,0xFF,0,0xD],1) == 0xFF_000D00;
+    // U64
+    assert ReadUint64([],0) == 0;
+    assert ReadUint64([0],0) == 0;
+    assert ReadUint64([0xFF],0) == 0xFF00_0000_0000_0000;
+    assert ReadUint64([0,0xFF],0) == 0x00FF_0000_0000_0000;
+    assert ReadUint64([0,0xFF,0],0) == 0x00FF_0000_0000_0000;
+    assert ReadUint64([0,0xFF,0,0xD],0) == 0x00FF_000D_0000_0000;
+    assert ReadUint64([0,0xFF,0,0xD],1) == 0xFF_000D00_0000_0000;
+    assert ReadUint64([0,0xFF,0,0xD,0xA,0xB],0) == 0x00FF_000D_0A0B_0000;
+    assert ReadUint64([0,0xFF,0,0xD,0xA,0xB],1) == 0xFF_000D0A_0B00_0000;
+    assert ReadUint64([0xFF,0xA,0xB,0xC,0xD, 0xE,0xF,0x1A,0x1B],1) == 0x0A0B0C0D0E0F1A1B;
+    // U128
+    assert ReadUint128([],0) == 0;
+    assert ReadUint128([0],0) == 0;
+    assert ReadUint128([0xFF],0) == 0xFF000000_00000000_00000000_00000000;
+    assert ReadUint128([0,0xFF],0) == 0x00FF0000_00000000_00000000_00000000;
+    assert ReadUint128([0,0xFF,0],0) == 0x00FF0000_00000000_00000000_00000000;
+    assert ReadUint128([0,0xFF,0,0xD],0) == 0x00FF000D_00000000_00000000_00000000;
+    assert ReadUint128([0,0xFF,0,0xD],1) == 0xFF000D00_00000000_00000000_00000000;
+    assert ReadUint128([0,0xFF,0,0xD,0xA,0xB],0) == 0x00FF000D_0A0B0000_00000000_00000000;
+    assert ReadUint128([0,0xFF,0,0xD,0xA,0xB],1) == 0xFF_000D0A_0B00_0000_00000000_00000000;
+    assert ReadUint128([0xFF,0xA,0xB,0xC,0xD, 0xE,0xF,0x1A,0x1B],1) == 0x0A0B0C0D0E0F1A1B_00000000_00000000;
+    assert ReadUint128([0xFF,0xA,0xB,0xC,0xD,0xE,0xF,0x1A,0x1B, 0x1C,0x1D,0x1E,0x1F,0x2A,0x2B,0x2C,0x2D],1) == 0x0A0B0C0D0E0F1A1B_1C1D1E1F2A2B2C2D;
+    // U256
+    assert ReadUint256([],0) == 0;
+    assert ReadUint256([0],0) == 0;
+    assert ReadUint256([],0) == 0;
+    assert ReadUint256([0],0) == 0;
+    assert ReadUint256([0xFF],0) == 0xFF00000000000000_0000000000000000_0000000000000000_0000000000000000;
+    assert ReadUint256([0,0xFF],0) == 0x00FF000000000000_0000000000000000_0000000000000000_0000000000000000;
+    assert ReadUint256([0,0xFF,0],0) == 0x00FF000000000000_0000000000000000_0000000000000000_0000000000000000;
+    assert ReadUint256([0,0xFF,0,0xD],0) == 0x00FF000D00000000_0000000000000000_0000000000000000_0000000000000000;
+    assert ReadUint256([0,0xFF,0,0xD],1) == 0xFF000D0000000000_0000000000000000_0000000000000000_0000000000000000;
+    assert ReadUint256([0,0xFF,0,0xD,0xA,0xB],0) == 0x00FF000D0A0B0000_0000000000000000_0000000000000000_0000000000000000;
+    assert ReadUint256([0,0xFF,0,0xD,0xA,0xB],1) == 0xFF000D0A0B000000_0000000000000000_0000000000000000_0000000000000000;
+    assert ReadUint256([0xFF,0xA,0xB,0xC,0xD, 0xE,0xF,0x1A,0x1B],1) == 0x0A0B0C0D0E0F1A1B_0000000000000000_0000000000000000_0000000000000000;
+    assert ReadUint256([0xFF,0xA,0xB,0xC,0xD,0xE,0xF,0x1A,0x1B, 0x1C,0x1D,0x1E,0x1F,0x2A,0x2B,0x2C,0x2D],1) == 0x0A0B0C0D0E0F1A1B_1C1D1E1F2A2B2C2D_0000000000000000_0000000000000000;
+    assert ReadUint256([0xFF,0xA,0xB,0xC,0xD,0xE,0xF,0x1A,0x1B, 0x1C,0x1D,0x1E,0x1F,0x2A,0x2B,0x2C,0x2D, 0x2E,0x2F,0x3A,0x3B,0x3C,0x3D,0x3E,0x3F,  0x4A,0x4B,0x4C,0x4D,0x4E,0x4F,0x5A,0x5B],1) == 0x0A0B0C0D0E0F1A1B_1C1D1E1F2A2B2C2D_2E2F3A3B3C3D3E3F_4A4B4C4D4E4F5A5B;
+}
+
+method {:test} SliceTests() {
+    assert Slice([0],0,0) == [];
+    assert Slice([0],0,1) == [0];
+    assert Slice([1],0,1) == [1];
+    assert Slice([1,2],0,1) == [1];
+    assert Slice([1,2],1,1) == [2];
+    assert Slice([1,2],1,2) == [2,0];
+    assert Slice([1,2,3],1,2) == [2,3];
+}
+
+method {:test} LeftPadTests() {
+    assert LeftPad([0],2) == [0,0];
+    assert LeftPad([1],2) == [0,1];
+    assert LeftPad([1],4) == [0,0,0,1];
+    assert LeftPad([1,2],4) == [0,0,1,2];
+}

--- a/src/test/dafny/IntTests.dfy
+++ b/src/test/dafny/IntTests.dfy
@@ -1,0 +1,145 @@
+include "../../dafny/util/int.dfy"
+
+import opened Int
+
+// Various tests for roundup
+method {:test} RoundUpTests() {
+    assert RoundUp(2,16) == 16;
+    assert RoundUp(16,16) == 16;
+    assert RoundUp(17,16) == 32;
+    assert RoundUp(31,16) == 32;
+    assert RoundUp(32,16) == 32;
+    assert RoundUp(33,16) == 48;
+}
+
+// Various sanity tests for division.
+method {:test} DivTests() {
+    // pos-pos
+    assert Div(6,2) == 3;
+    assert Div(6,3) == 2;
+    assert Div(6,4) == 1;
+    assert Div(9,4) == 2;
+    // neg-pos
+    assert Div(-6,2) == -3;
+    assert Div(-6,3) == -2;
+    assert Div(-6,4) == -1;
+    assert Div(-9,4) == -2;
+    // pos-neg
+    assert Div(6,-2) == -3;
+    assert Div(6,-3) == -2;
+    assert Div(6,-4) == -1;
+    assert Div(9,-4) == -2;
+    // neg-neg
+    assert Div(-6,-2) == 3;
+    assert Div(-6,-3) == 2;
+    assert Div(-6,-4) == 1;
+    assert Div(-9,-4) == 2;
+}
+
+// Various sanity tests for Remainder.
+method {:test} RemTests() {
+    // pos-pos
+    assert Rem(6,2) == 0;
+    assert Rem(6,3) == 0;
+    assert Rem(6,4) == 2;
+    assert Rem(9,4) == 1;
+    // neg-pos
+    assert Rem(-6,2) == 0;
+    assert Rem(-6,3) == 0;
+    assert Rem(-6,4) == -2;
+    assert Rem(-9,4) == -1;
+    // pos-neg
+    assert Rem(6,-2) == 0;
+    assert Rem(6,-3) == 0;
+    assert Rem(6,-4) == 2;
+    assert Rem(9,-4) == 1;
+    // neg-neg
+    assert Rem(-6,-2) == 0;
+    assert Rem(-6,-3) == 0;
+    assert Rem(-6,-4) == -2;
+    assert Rem(-9,-4) == -1;
+}
+
+ // Various sanity tests for exponentiation.
+method {:test} PowTests() {
+    assert Pow(2,8) == TWO_8;
+    assert Pow(2,15) == TWO_15;
+    assert Pow(2,16) == TWO_16;
+    assert Pow(2,24) == TWO_24;
+    assert Pow(2,31) == TWO_31;
+    assert Pow(2,32) == TWO_32;
+    assert Pow(2,40) == TWO_40;
+    assert Pow(2,48) == TWO_48;
+    assert Pow(2,56) == TWO_56;
+    assert Pow(2,63) == TWO_63;
+    assert Pow(2,64) == TWO_64;
+    // NOTE:  I have to break the following ones up because Z3
+    // cannot handle it.
+    assert Pow(2,63) * Pow(2,64) == TWO_127;
+    assert Pow(2,64) * Pow(2,64) == TWO_128;
+    assert Pow(2,64) * Pow(2,64) * Pow(2,64) * Pow(2,64) == TWO_256;
+    assert (TWO_128 / TWO_64) == TWO_64;
+    assert (TWO_256 / TWO_128) == TWO_128;
+}
+
+method {:test} NthUint8Tests() {
+    assert U16.NthUint8(0xde80,0) == 0xde;
+    assert U16.NthUint8(0xde80,1) == 0x80;
+    // U32
+    assert U32.NthUint16(0x1230de80,0) == 0x1230;
+    assert U32.NthUint16(0x1230de80,1) == 0xde80;
+    // U64
+    assert U64.NthUint32(0x00112233_44556677,0) == 0x00112233;
+    assert U64.NthUint32(0x00112233_44556677,1) == 0x44556677;
+    // U128
+    assert U128.NthUint64(0x0011223344556677_8899AABBCCDDEEFF,0) == 0x0011223344556677;
+    assert U128.NthUint64(0x0011223344556677_8899AABBCCDDEEFF,1) == 0x8899AABBCCDDEEFF;
+    // U256
+    assert U256.NthUint128(0x00112233445566778899AABBCCDDEEFF_FFEEDDCCBBAA99887766554433221100,0) == 0x00112233445566778899AABBCCDDEEFF;
+    assert U256.NthUint128(0x00112233445566778899AABBCCDDEEFF_FFEEDDCCBBAA99887766554433221100,1) == 0xFFEEDDCCBBAA99887766554433221100;
+    assert U256.NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,00) == 0x00;
+    assert U256.NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,01) == 0x01;
+    assert U256.NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,02) == 0x02;
+    assert U256.NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,03) == 0x03;
+    assert U256.NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,04) == 0x04;
+    assert U256.NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,05) == 0x05;
+    assert U256.NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,06) == 0x06;
+    assert U256.NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,07) == 0x07;
+    assert U256.NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,08) == 0x08;
+    assert U256.NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,09) == 0x09;
+    assert U256.NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,10) == 0x0A;
+    assert U256.NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,11) == 0x0B;
+    assert U256.NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,12) == 0x0C;
+    assert U256.NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,13) == 0x0D;
+    assert U256.NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,14) == 0x0E;
+    assert U256.NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,15) == 0x0F;
+    assert U256.NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,16) == 0x10;
+    assert U256.NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,17) == 0x11;
+    assert U256.NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,18) == 0x12;
+    assert U256.NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,19) == 0x13;
+    assert U256.NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,20) == 0x14;
+    assert U256.NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,21) == 0x15;
+    assert U256.NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,22) == 0x16;
+    assert U256.NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,23) == 0x17;
+    assert U256.NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,24) == 0x18;
+    assert U256.NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,25) == 0x19;
+    assert U256.NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,26) == 0x1A;
+    assert U256.NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,27) == 0x1B;
+    assert U256.NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,28) == 0x1C;
+    assert U256.NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,29) == 0x1D;
+    assert U256.NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,30) == 0x1E;
+    assert U256.NthUint8(0x000102030405060708090A0B0C0D0E0F_101112131415161718191A1B1C1D1E1F,31) == 0x1F;
+}
+
+method {:test} WordTests() {
+    // ==>
+    assert Word.asI256(0) == 0;
+    assert Word.asI256(MAX_U256 as u256) == -1;
+    assert Word.asI256(MAX_I256 as u256) == (MAX_I256 as i256);
+    assert Word.asI256((MAX_I256 + 1) as u256) == (MIN_I256 as i256);
+    // <==
+    assert Word.fromI256(0) == 0;
+    assert Word.fromI256(-1) == (MAX_U256 as u256);
+    assert Word.fromI256(MAX_I256 as i256) == (MAX_I256 as u256);
+    assert Word.fromI256(MIN_I256 as i256) == (TWO_255 as u256);
+}


### PR DESCRIPTION
This moves tests out of ints.dfy and bytes.dfy into various files within
the src/test/dafny folder.  This also adds a bunch of tests for reading
ints from byte sequences.