### PR TITLE
Improve Call API; add examples #182

### DIFF
--- a/src/dafny/bytecode.dfy
+++ b/src/dafny/bytecode.dfy
@@ -1009,7 +1009,7 @@ module Bytecode {
     /**
      * Message-call into an account.
      */
-    function method Call(st: State) : State
+    function method Call(st: State) : (nst: State)
     requires !st.IsFailure() {
         //
         if st.Operands() >= 7
@@ -1018,7 +1018,7 @@ module Bytecode {
             var outOffset := st.Peek(5) as nat;
             var inSize := st.Peek(4) as nat;
             var inOffset := st.Peek(3) as nat;
-            var value := st.Peek(2) as nat;
+            var value := st.Peek(2);
             var to := (st.Peek(1) as int) % TWO_160;
             var gas := st.Peek(0) as nat;
              // Sanity check bounds
@@ -1028,7 +1028,7 @@ module Bytecode {
                 // Compute the continuation (i.e. following) state.
                 var nst := st.Expand(inOffset,inSize).Pop().Pop().Pop().Pop().Pop().Pop().Pop().Next();
                 // Pass back continuation.
-                State.CALLS(nst.evm,to as u160,calldata, outOffset:=outOffset, outSize:=outSize)
+                State.CALLS(nst.evm,to as u160, gas, value, calldata, outOffset:=outOffset, outSize:=outSize)
             else
                 State.INVALID(MEMORY_OVERFLOW)
         else

--- a/src/dafny/util/int.dfy
+++ b/src/dafny/util/int.dfy
@@ -118,6 +118,20 @@ module Int {
         (b1 * (TWO_32 as u64)) + b2
     }
 
+    function method ReadUint128(bytes: seq<u8>, address:nat) : u128
+    requires (address+15) < |bytes| {
+        var b1 := ReadUint64(bytes, address) as u128;
+        var b2 := ReadUint64(bytes, address+8) as u128;
+        (b1 * (TWO_64 as u128)) + b2
+    }
+
+    function method ReadUint256(bytes: seq<u8>, address:nat) : u256
+    requires (address+31) < |bytes| {
+        var b1 := ReadUint128(bytes, address) as u256;
+        var b2 := ReadUint128(bytes, address+16) as u256;
+        (b1 * (TWO_128 as u256)) + b2
+    }
+
     // =========================================================
     // Exponent
     // =========================================================

--- a/src/main/java/dafnyevm/DafnyEvm.java
+++ b/src/main/java/dafnyevm/DafnyEvm.java
@@ -307,10 +307,9 @@ public class DafnyEvm {
 			// Make the recursive call.
 			State nr = new DafnyEvm().tracer(tracer).putAll(worldState).from(to).to(cc.receiver()).origin(origin)
 					.data(cc.callData()).call();
-			boolean success = nr instanceof State.Return;
 			// FIXME: update worldstate upon success.
 			// Continue from where we left off.
-			r = cc.callContinue(success, nr.getReturnData());
+			r = cc.callReturn(nr);
 		}
 		return r;
 	}
@@ -533,7 +532,7 @@ public class DafnyEvm {
 			 */
 			public byte[] callData() {
 				State_CALLS sok = (State_CALLS) state;
-				return DafnySequence.toByteArray((DafnySequence) sok.calldata);
+				return DafnySequence.toByteArray((DafnySequence) sok.callData);
 			}
 
 			@Override
@@ -547,13 +546,9 @@ public class DafnyEvm {
 			 *
 			 * @return
 			 */
-			public State callContinue(boolean success, byte[] returnData) {
-				// Determine appropriate exit code.
-				BigInteger exitCode = success ? BigInteger.ONE : BigInteger.ZERO;
-				// Sanitise the return data.
-				returnData = (returnData == null) ? new byte[0] : returnData;
+			public State callReturn(State callee) {
 				// Convert into OK state
-				EvmState_Compile.State st = state.CallReturn(exitCode, DafnySequence.fromBytes(returnData));
+				EvmState_Compile.State st = state.CallReturn(callee.state);
 				// Continue execution.
 				return run(tracer, st);
 			}

--- a/src/test/dafny/CallExample.dfy
+++ b/src/test/dafny/CallExample.dfy
@@ -1,0 +1,106 @@
+// An set of examples illustrating contract calls.
+include "../../dafny/evm.dfy"
+include "../../dafny/evms/berlin.dfy"
+
+module CallExamples {
+    import opened Int
+    import opened Opcode
+    import opened Memory
+    import EvmBerlin
+    import opened Bytecode
+    import Bytes
+
+    /** The gas loaded in the EVM before executing a program. */
+    const INITGAS := 0xFFFF;
+
+    method test_call_01() {
+        // This is an absolutely minimal example of a contract call where the
+        // called contract just stops.  Since the called contract stopped
+        // successfully, we can at least check the exit code.
+        var vm1 := EvmBerlin.InitEmpty(gas := INITGAS);
+        vm1 := Push1(vm1,0x0); // Out size
+        vm1 := Dup(vm1,1);     // Out offset
+        vm1 := Dup(vm1,1);     // In size
+        vm1 := Dup(vm1,1);     // In offset
+        vm1 := Dup(vm1,1);     // Call value
+        vm1 := Push2(vm1,0xccc); // To address
+        vm1 := Push1(vm1,0x3); // Gas
+        vm1 := Call(vm1);
+        // >>> Contract call starts here
+        {
+            var vm2 := vm1.CallEnter(map[],[]);
+            vm2 := Stop(vm2);
+            vm1 := vm1.CallReturn(vm2);
+        }
+        // <<< Contract call ends here
+        assert vm1.OK?;
+        // Check exit code loaded correctly.
+        assert vm1.Peek(0) == 1;
+    }
+
+    method test_call_02() {
+        // This is another simple example of a contract call where the called
+        // contract raises an exception.
+        var vm1 := EvmBerlin.InitEmpty(gas := INITGAS);
+        vm1 := Push1(vm1,0x0); // Out size
+        vm1 := Dup(vm1,1);     // Out offset
+        vm1 := Dup(vm1,1);     // In size
+        vm1 := Dup(vm1,1);     // In offset
+        vm1 := Dup(vm1,1);     // Call value
+        vm1 := Push2(vm1,0xccc); // To address
+        vm1 := Push1(vm1,0x3); // Gas
+        vm1 := Call(vm1);
+        // >>> Contract call starts here
+        {
+            var vm2 := vm1.CallEnter(map[],[]);
+            vm2 := Pop(vm2); // force exception
+            vm1 := vm1.CallReturn(vm2);
+        }
+        // <<< Contract call ends here
+        assert vm1.OK?;
+        // Check exit code loaded correctly.
+        assert vm1.Peek(0) == 0;
+    }
+
+    method test_call_03() {
+        // This is another simple example of a contract call where the called
+        // contract returns some return data.
+        var vm1 := EvmBerlin.InitEmpty(gas := INITGAS);
+        vm1 := Push1(vm1,0x20);  // Out size
+        vm1 := Push1(vm1,0x0);   // Out offset
+        vm1 := Dup(vm1,1);       // In size
+        vm1 := Dup(vm1,1);       // In offset
+        vm1 := Dup(vm1,1);       // Call value
+        vm1 := Push2(vm1,0xccc); // To address
+        vm1 := Push1(vm1,0xFF);   // Gas
+        vm1 := Call(vm1);
+        { // >>> Contract call starts here
+            var vm2 := vm1.CallEnter(map[],[]);
+            vm2 := contractReturns123(vm2);
+            vm1 := vm1.CallReturn(vm2);
+        } // <<< Contract call ends here
+        // Check exit code loaded correctly.
+        assert vm1.Peek(0) == 1;
+        // Extract return data
+        vm1 := Push1(vm1,0x00);
+        vm1 := MLoad(vm1);
+        // Check return data.
+        assert vm1.Peek(0) == 0x123;
+    }
+
+    method contractReturns123(vm:EvmState.State) returns (vm':EvmState.State)
+    requires vm.OK?
+    requires vm.Capacity() > 3 && vm.MemSize() == 0
+    // Returns exactly 32 bytes of data
+    ensures vm'.RETURNS? && |vm'.data| == 32
+    // Returns exactly 0x123
+    ensures Int.ReadUint256(vm'.data,0) == 0x123 {
+        vm' := vm;
+        vm' := Push2(vm',0x123);
+        vm' := Push1(vm',0x00);
+        vm' := MStore(vm');
+        vm' := Push1(vm',0x20);
+        vm' := Push1(vm',0x00);
+        vm' := Return(vm'); // force return
+    }
+}

--- a/src/test/java/dafnyevm/Tests.java
+++ b/src/test/java/dafnyevm/Tests.java
@@ -1437,10 +1437,8 @@ public class Tests {
 
 	@Test
 	public void test_call_01() {
-		// Address of contract to call
-
-		//
-		// Contract call which returns 0x123, and this is then returned by the caller.
+		// Absolutely minimal contract call which does nothing, and the caller then
+		// returns the (successful) exit code.
 		DafnyEvm tx = new DafnyEvm().put(CONTRACT_1, new Account(toBytes(STOP)));
 		byte[] output = call(tx, new int[] {
 				// Make contract call to 0xccc with gas 0xffff


### PR DESCRIPTION
This adds three examples which illustrate verification of contract
calls.  Furthermore, the call API is improved and makes the examples
reasonably nice.  I did have some problems verifying the largest
example, however, and I was forced to split it into a separate method
call.