### PR TITLE
Support EXTCODEHASH #301

### DIFF
--- a/src/dafny/bytecode.dfy
+++ b/src/dafny/bytecode.dfy
@@ -790,6 +790,23 @@ module Bytecode {
     }
 
     /**
+     * Get size of an account's code.
+     */
+    function method ExtCodeHash(st: State) : State
+    requires !st.IsFailure() {
+        if st.Operands() >= 1
+        then
+            // Extract contract account
+            var account := (st.Peek(0) as nat % TWO_160) as u160;
+            // Lookup account
+            var data := st.evm.world.GetOrDefault(account);
+            // Done
+            st.AccountAccessed(account).Pop().Push(data.hash).Next()
+        else
+            State.INVALID(STACK_UNDERFLOW)
+    }
+
+    /**
      * Get size of return data from the previous call from the current
      * environment.
      */

--- a/src/dafny/evms/berlin.dfy
+++ b/src/dafny/evms/berlin.dfy
@@ -105,7 +105,7 @@ module EvmBerlin refines EVM {
                         case EXTCODECOPY => Bytecode.ExtCodeCopy(s)
                         case RETURNDATASIZE => Bytecode.ReturnDataSize(s)
                         case RETURNDATACOPY => Bytecode.ReturnDataCopy(s)
-                        //  EXTCODEHASH => Bytecode.evalEXTCODEHASH(s),
+                        case EXTCODEHASH => Bytecode.ExtCodeHash(s)
                         // 0x40s: Block Information
                         case BLOCKHASH => Bytecode.BlockHash(s)
                         case COINBASE => Bytecode.CoinBase(s)

--- a/src/dafny/gas.dfy
+++ b/src/dafny/gas.dfy
@@ -447,7 +447,7 @@ module Gas {
             case EXTCODECOPY => s.UseGas(CostExpandRange(s,4,1,3) + CostExtAccount(s) + CostCopy(s,3))
             case RETURNDATASIZE => s.UseGas(G_BASE)
             case RETURNDATACOPY => s.UseGas(CostExpandRange(s,3,0,2) + G_VERYLOW + CostCopy(s,2))
-            //  EXTCODEHASH => s.UseGas(1)
+            case EXTCODEHASH => s.UseGas(CostExtAccount(s))
             // 0x40s: Block Information
             case BLOCKHASH => s.UseGas(G_BLOCKHASH)
             case COINBASE => s.UseGas(G_BASE)

--- a/src/dafny/opcodes.dfy
+++ b/src/dafny/opcodes.dfy
@@ -62,6 +62,7 @@ module Opcode {
 	const EXTCODECOPY : u8 := 0x3c;
 	const RETURNDATASIZE : u8 := 0x3d;
 	const RETURNDATACOPY : u8 := 0x3e;
+    const EXTCODEHASH : u8 := 0x3f;
 	// 40s: Block Information
 	const BLOCKHASH : u8 := 0x40;
 	const COINBASE : u8 := 0x41;

--- a/src/dafny/state.dfy
+++ b/src/dafny/state.dfy
@@ -691,7 +691,7 @@ module EvmState {
             var endowment := ctx.callValue;
             var storage := Storage.Create(map[]); // empty
             var code := Code.Create(initcode);
-            var account := WorldState.Account(1,endowment,storage,code);
+            var account := WorldState.CreateAccount(1,endowment,storage,code);
             // Create initial account
             var w := world.Put(ctx.address,account).IncNonce(ctx.sender);
             // When creating end-use account, return immediately.

--- a/src/main/java/dafnyevm/DafnyEvm.java
+++ b/src/main/java/dafnyevm/DafnyEvm.java
@@ -304,7 +304,7 @@ public class DafnyEvm {
 	public DafnyEvm create(BigInteger address, BigInteger nonce, BigInteger endowment, Map<BigInteger, BigInteger> storage, byte[] bytecode) {
 		Storage_Compile.T store = Storage_Compile.T.create(new DafnyMap<BigInteger,BigInteger>(storage));
 		Code_Compile.Raw code = new Code_Compile.Raw(DafnySequence.fromBytes(bytecode));
-		WorldState_Compile.Account acct = new WorldState_Compile.Account(nonce, endowment, store,code);
+		WorldState_Compile.Account acct = WorldState_Compile.__default.CreateAccount(nonce, endowment, store,code);
 		this.worldState = DafnyMap.update(worldState, address, acct);
 		return this;
 	}

--- a/src/test/java/dafnyevm/Tests.java
+++ b/src/test/java/dafnyevm/Tests.java
@@ -18,6 +18,7 @@ import java.util.Arrays;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Test;
+import org.web3j.crypto.Hash;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -969,6 +970,14 @@ public class Tests {
 		byte[] output = callWithReturn(tx,
 				new int[] { PUSH1, 0x20, PUSH1, 0x00, PUSH1, 0x00, PUSH2, 0x0c, 0xcc, EXTCODECOPY, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(Hex.toBytes("0x60206000f3000000000000000000000000000000000000000000000000000000"), output);
+	}
+
+	@Test
+	public void test_extcodehash_01() {
+		byte[] bytes = toBytes(PUSH1, 0x20, PUSH1, 0x00, RETURN);
+		DafnyEvm tx = new DafnyEvm().create(CONTRACT_1, bytes);
+		byte[] output = callWithReturn(tx, new int[] { PUSH2, 0xc, 0xcc, EXTCODEHASH, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
+		assertArrayEquals(Hash.sha3(bytes), output);
 	}
 
 	@Test


### PR DESCRIPTION
This adds support for the bytecode.  The implementation of this is achieved using `External.sha3()`.