### PR TITLE
Fix EXTCODEHASH and EXTCODESIZE #351

### DIFF
--- a/src/dafny/bytecode.dfy
+++ b/src/dafny/bytecode.dfy
@@ -745,12 +745,17 @@ module Bytecode {
         then
             // Extract contract account
             var account := (st.Peek(0) as nat % TWO_160) as u160;
-            // Lookup account
-            var data := st.evm.world.GetOrDefault(account);
-            // Determine its code size
-            var size := |data.code.contents| as u256;
-            // Done
-            st.AccountAccessed(account).Pop().Push(size).Next()
+            // Sanity check aliveness
+            if st.IsDead(account)
+            then
+                st.AccountAccessed(account).Pop().Push(0).Next()
+            else
+                // Lookup account
+                var data := st.evm.world.GetOrDefault(account);
+                // Determine its code size
+                var size := |data.code.contents| as u256;
+                // Done
+                st.AccountAccessed(account).Pop().Push(size).Next()
         else
             State.INVALID(STACK_UNDERFLOW)
     }
@@ -798,10 +803,15 @@ module Bytecode {
         then
             // Extract contract account
             var account := (st.Peek(0) as nat % TWO_160) as u160;
-            // Lookup account
-            var data := st.evm.world.GetOrDefault(account);
-            // Done
-            st.AccountAccessed(account).Pop().Push(data.hash).Next()
+            // Sanity check aliveness
+            if st.IsDead(account)
+            then
+                st.AccountAccessed(account).Pop().Push(0).Next()
+            else
+                // Lookup account
+                var data := st.evm.world.Get(account).Unwrap();
+                // Done
+                st.AccountAccessed(account).Pop().Push(data.hash).Next()
         else
             State.INVALID(STACK_UNDERFLOW)
     }

--- a/src/test/java/dafnyevm/GeneralStateTests.java
+++ b/src/test/java/dafnyevm/GeneralStateTests.java
@@ -130,19 +130,12 @@ public class GeneralStateTests {
 			"stRevertTest/RevertInCreateInInit.json", // #343
 			"stRevertTest/PythonRevertTestTue201814-1430.json", // #349
 			"VMTests/vmArithmeticTest/twoOps.json", // #350
-			"stExtCodeHash/extCodeHashDynamicArgument.json", // #351
-			"stExtCodeHash/extCodeHashSubcallOOG.json", // #351
-			"stExtCodeHash/extCodeHashPrecompiles.json", // #351
-			"stExtCodeHash/extCodeHashNonExistingAccount.json", // #351
-			"stExtCodeHash/extcodehashEmpty.json", // #351
-			"stExtCodeHash/codeCopyZero.json", // #351
-			"stExtCodeHash/callToNonExistent.json", // #351
-			"stExtCodeHash/dynamicAccountOverwriteEmpty.json", // #351
 			// Unknowns
 			"stCreateTest/CREATE_ContractRETURNBigOffset.json", // large return?
 			"stCreateTest/CREATE_ContractSSTOREDuringInit.json",
 			"stCreateTest/CREATE_EContractCreateEContractInInit_Tr.json",
 			"stCreateTest/CREATE_EContractCreateNEContractInInit_Tr.json",
+			"stExtCodeHash/extcodehashEmpty.json", // ?
 			"VMTests/vmArithmeticTest/exp.json", // too slow?
 			//
 			"stCallCodes/callcodeInInitcodeToEmptyContract.json",


### PR DESCRIPTION
This puts through some simple fixes for the cases where we attempt to run these bytecodes on non-existent contracts.