### PR TITLE
Fix #357

### DIFF
--- a/src/dafny/bytecode.dfy
+++ b/src/dafny/bytecode.dfy
@@ -1115,7 +1115,7 @@ module Bytecode {
             // Store word
             st.Pop().Pop().Store(loc,val).KeyAccessed(loc).Next()
         else
-        State.INVALID(STACK_UNDERFLOW)
+            State.INVALID(STACK_UNDERFLOW)
     }
 
     /**

--- a/src/dafny/gas.dfy
+++ b/src/dafny/gas.dfy
@@ -517,7 +517,13 @@ module Gas {
     // returns the amount of gas to charge upon the execution of SSTORE
     function method CostSSTORE(st: State): nat
     requires !st.IsFailure() {
-        CostSSTOREChargeRefund(st).0
+        if st.Gas() <= G_CALLSTIPEND
+        then
+            // NOTE: The following forces an out-of-gas exception if the stipend
+            // would be jeorpodised, as following the yellow paper.
+            MAX_U256
+        else
+            CostSSTOREChargeRefund(st).0
     }
 
     // sets in the refund component of the substate the refund amount computed upon the execution of SSTORE

--- a/src/test/java/dafnyevm/GeneralStateTests.java
+++ b/src/test/java/dafnyevm/GeneralStateTests.java
@@ -102,6 +102,7 @@ public class GeneralStateTests {
 			"stMemoryTest/oog.json", // #299
 			"stCreateTest/CREATE_FirstByte_loop.json", // #299
 			"stCreateTest/CREATE_HighNonce.json", // #329
+			"stCreate2/CREATE2_HighNonceDelegatecall.json", // #329
 			"stCreate2/CREATE2_HighNonce.json", // #329
 			"stSStoreTest/sstore_0to0.json", // #331
 			"stSStoreTest/sstore_0to0to0.json", // #331
@@ -128,7 +129,17 @@ public class GeneralStateTests {
 			"stCreate2/create2noCash.json", // #331
 			"stExtCodeHash/callToSuicideThenExtcodehash.json", // #331
 			"stExtCodeHash/extCodeHashCreatedAndDeletedAccountStaticCall.json", // #331
+			"stSStoreTest/sstore_changeFromExternalCallInInitCode.json", // #331
+			"stCreate2/create2checkFieldsInInitcode.json", // #331
 			"stRevertTest/RevertInCreateInInit.json", // #343
+			"stSStoreTest/InitCollision.json", // #347
+			"stRevertTest/LoopCallsDepthThenRevert2.json", // #358
+			"stRevertTest/LoopCallsDepthThenRevert3.json", // #358
+			"stCallCodes/callcodeEmptycontract.json", // #359
+			"stCallCodes/callcodeInInitcodeToEmptyContract.json", // #359
+			"stCreateTest/CREATE_EContractCreateNEContractInInitOOG_Tr.json", // #360
+			"stCreateTest/CREATE_empty000CreateinInitCode_Transaction.json", // #360
+			"stCreateTest/TransactionCollisionToEmpty.json", // #360
 			// Unknowns
 			"stCreateTest/CREATE_ContractRETURNBigOffset.json", // large return?
 			"stCreateTest/CREATE_ContractSSTOREDuringInit.json",
@@ -136,31 +147,9 @@ public class GeneralStateTests {
 			"stCreateTest/CREATE_EContractCreateNEContractInInit_Tr.json",
 			"VMTests/vmArithmeticTest/exp.json", // too slow?
 			//
-			"stCallCodes/callcodeInInitcodeToEmptyContract.json",
-			"stCallCodes/callcodeEmptycontract.json",
 			"stCreate2/RevertInCreateInInitCreate2.json",
-			"stCreateTest/CreateCollisionResults.json",
-			"stRevertTest/LoopDelegateCallsDepthThenRevert.json",
-			"stCallCodes/callcallcall_ABCB_RECURSIVE.json",
-			"stCallCodes/callcallcallcode_ABCB_RECURSIVE.json",
-			"stCallCodes/callcallcodecall_ABCB_RECURSIVE.json",
-			"stCallCodes/callcallcodecallcode_ABCB_RECURSIVE.json",
-			"stCallCodes/callcodecallcall_ABCB_RECURSIVE.json",
-			"stCallCodes/callcodecallcallcode_ABCB_RECURSIVE.json",
-			"stCallCodes/callcodecallcodecall_ABCB_RECURSIVE.json",
-			"stCallCodes/callcodecallcodecallcode_ABCB_RECURSIVE.json",
-			"stCreateTest/CREATE_EContractCreateNEContractInInitOOG_Tr.json",
-			"stCreateTest/CREATE_empty000CreateinInitCode_Transaction.json",
-			"stCreateTest/TransactionCollisionToEmpty.json",
-			"stCreate2/CREATE2_HighNonceDelegatecall.json",
-			"stCreate2/create2checkFieldsInInitcode.json",
-			"stRevertTest/LoopCallsDepthThenRevert2.json",
-			"stRevertTest/LoopCallsDepthThenRevert3.json",
-			"stRevertTest/LoopCallsDepthThenRevert.json",
-			"stSStoreTest/InitCollision.json",
+			"stCreateTest/CreateCollisionResults.json", // ?
 			"stSStoreTest/InitCollisionNonZeroNonce.json",
-			"stSStoreTest/sstore_changeFromExternalCallInInitCode.json",
-			"stSStoreTest/sstore_gasLeft.json",
 			"dummy"
 	);
 


### PR DESCRIPTION
This implements a missing check from the yellow paper based on SSTORE requiring _at least_ G_STIPEND gas to continue.  This also further classifies remaining tests.