### PR TITLE
Fix #359

### DIFF
--- a/src/dafny/util/precompiled.dfy
+++ b/src/dafny/util/precompiled.dfy
@@ -124,6 +124,7 @@ module Precompiled {
     /**
      * Compute arbitrary precision exponentiation under modulo.  Specifically,
      * we compue B^E % M.  All words are unsigned integers in big endian format.
+     * See also EIP-2565.
      */
     function method CallModExp(data: seq<u8>) : Option<(seq<u8>,nat)> {
         // Length of B

--- a/src/test/java/dafnyevm/GeneralStateTests.java
+++ b/src/test/java/dafnyevm/GeneralStateTests.java
@@ -133,8 +133,6 @@ public class GeneralStateTests {
 			"stCreate2/create2checkFieldsInInitcode.json", // #331
 			"stRevertTest/RevertInCreateInInit.json", // #343
 			"stSStoreTest/InitCollision.json", // #347
-			"stCallCodes/callcodeEmptycontract.json", // #359
-			"stCallCodes/callcodeInInitcodeToEmptyContract.json", // #359
 			"stCreateTest/CREATE_EContractCreateNEContractInInitOOG_Tr.json", // #360
 			"stCreateTest/CREATE_empty000CreateinInitCode_Transaction.json", // #360
 			"stCreateTest/TransactionCollisionToEmpty.json", // #360


### PR DESCRIPTION
This adjusts the gas cost calculation for CALLCODE and DELEGATECALL. The calculations in the Yellow Paper appear to contradict what is in the execution-specs and what clients like Geth actually implement.