### PR TITLE
Fixes for #299

### DIFF
--- a/src/dafny/bytecode.dfy
+++ b/src/dafny/bytecode.dfy
@@ -1333,8 +1333,8 @@ module Bytecode {
             var code := Memory.Slice(st.evm.memory, codeOffset, codeSize);
             // Calculate available gas
             var gascap := GasCalc.CreateGasCap(st);
-            //
-            var nst := st.UseGas(gascap).Expand(codeOffset,codeSize).Pop().Pop().Pop().Next();
+            // Apply everything
+            var nst := st.UseGas(gascap).IncNonce().Expand(codeOffset,codeSize).Pop().Pop().Pop().Next();
             // Pass back continuation
             State.CREATES(nst.evm,gascap,endowment,code, None)
         else
@@ -1486,8 +1486,8 @@ module Bytecode {
             var code := Memory.Slice(st.evm.memory, codeOffset, codeSize);
             // Calculate available gas
             var gascap := GasCalc.CreateGasCap(st);
-            //
-            var nst := st.UseGas(gascap).Expand(codeOffset,codeSize).Pop().Pop().Pop().Pop().Next();
+            // Apply everything
+            var nst := st.UseGas(gascap).IncNonce().Expand(codeOffset,codeSize).Pop().Pop().Pop().Pop().Next();
             // Pass back continuation
             State.CREATES(nst.evm,gascap,endowment,code,Some(salt))
         else

--- a/src/dafny/state.dfy
+++ b/src/dafny/state.dfy
@@ -349,6 +349,14 @@ module EvmState {
         }
 
         /**
+         * Increment the nonce associated with the currently executing account.
+         */
+        function method IncNonce() : State
+        requires !IsFailure()  {
+             OK(evm.(world:=evm.world.IncNonce(evm.context.address)))
+        }
+
+        /**
          * Get the account associated with a given address.  If no such account
          * exists, none is returned.
          */
@@ -775,7 +783,7 @@ module EvmState {
             var storage := Storage.Create(map[]); // empty
             var account := WorldState.CreateAccount(1,endowment,storage,Code.Create([]));
             // Create initial account
-            var w := world.Put(ctx.address,account).IncNonce(ctx.sender);
+            var w := world.Put(ctx.address,account);
             // Deduct wei
             var nw := w.Withdraw(ctx.sender,endowment);
             // When creating end-use account, return immediately.

--- a/src/main/java/dafnyevm/DafnyEvm.java
+++ b/src/main/java/dafnyevm/DafnyEvm.java
@@ -430,9 +430,11 @@ public class DafnyEvm {
 		BigInteger sender = cc.dtor_evm().dtor_context().dtor_address();
 		// Construct new account
 		Account acct = cc.dtor_evm().dtor_world().dtor_accounts().get(sender);
+		// Subtract one from nonce (i.e. because it was already incremented prior to this point)
+		BigInteger nonce = acct.dtor_nonce().subtract(BigInteger.ONE);
 		// NOTE: we do not subtract one from the nonce here, as this address is being
 		// calculated *before* the sender's nonce is incremented.
-		byte[] hash = addr(sender, acct.dtor_nonce(), cc.dtor_salt(), cc.dtor_initcode());
+		byte[] hash = addr(sender, nonce, cc.dtor_salt(), cc.dtor_initcode());
 		// Finally reconstruct the address from the rightmost 160bits.
 		BigInteger address = new BigInteger(1, hash);
 		// Begin the recursive call.
@@ -473,7 +475,8 @@ public class DafnyEvm {
 		//
 		if (salt instanceof ExtraTypes_Compile.Option_None) {
 			// Case for CREATE
-			bytes = RlpEncoder.encode(new RlpList(RlpString.create(sender),RlpString.create(nonce)));
+			bytes = new Uint160(sender).getBytes();
+			bytes = RlpEncoder.encode(new RlpList(RlpString.create(bytes),RlpString.create(nonce)));
 		} else {
 			@SuppressWarnings({ "rawtypes", "unchecked" })
 			byte[] code = DafnySequence.toByteArray((DafnySequence) initCode);

--- a/src/main/java/dafnyevm/util/Word.java
+++ b/src/main/java/dafnyevm/util/Word.java
@@ -151,7 +151,7 @@ public abstract class Word {
 	 * @param bytes
 	 * @return
 	 */
-	private byte[] trim(int n, byte[] bytes) {
+	private static byte[] trim(int n, byte[] bytes) {
 		int i = 0;
 		while((bytes.length-i) > n && bytes[i] == 0) {
 			i = i + 1;

--- a/src/test/java/dafnyevm/GeneralStateTests.java
+++ b/src/test/java/dafnyevm/GeneralStateTests.java
@@ -98,9 +98,6 @@ public class GeneralStateTests {
 			"stReturnDataTest/modexp_modsize0_returndatasize.json", //
 			"stCreate2/create2callPrecompiles.json", // #266 (address 0x1)
 			"stCreate2/CREATE2_Suicide.json", // #274
-			"stExtCodeHash/extcodehashEmpty.json", // #299
-			"stMemoryTest/oog.json", // #299
-			"stCreateTest/CREATE_FirstByte_loop.json", // #299
 			"stCreateTest/CREATE_HighNonce.json", // #329
 			"stCreate2/CREATE2_HighNonceDelegatecall.json", // #329
 			"stCreate2/CREATE2_HighNonce.json", // #329
@@ -144,7 +141,7 @@ public class GeneralStateTests {
 			"VMTests/vmArithmeticTest/exp.json", // too slow?
 			//
 			"stCreate2/RevertInCreateInInitCreate2.json",
-			"stCreateTest/CreateCollisionResults.json", // ?
+			"stCreateTest/CreateCollisionResults.json", // gas after call
 			"stSStoreTest/InitCollisionNonZeroNonce.json",
 			"dummy"
 	);


### PR DESCRIPTION
This puts through two fixes related to contract creation.  Firstly, the sender address was not being correctly padded prior to RLP encoding. Secondly, the nonce for creation was being incremented at the wrong moment.  Specifically, it is incremented regardless of the whether the creation suceeded or failed.