### PR TITLE
Add gas checks for JUnit tests #185

### DIFF
--- a/src/main/java/dafnyevm/DafnyEvm.java
+++ b/src/main/java/dafnyevm/DafnyEvm.java
@@ -263,6 +263,14 @@ public class DafnyEvm {
 	}
 
 	/**
+	 * Get the gas limit for this call.
+	 * @return
+	 */
+	public BigInteger gas() {
+        return gas;
+    }
+
+	/**
 	 * Set the input data for this call.
 	 *
 	 * @param data
@@ -558,6 +566,13 @@ public class DafnyEvm {
 
 		public byte[] getReturnData() { return null; }
 
+        /**
+         * Get gas remaining.
+         *
+         * @return
+         */
+	    public abstract BigInteger getGas();
+
 		public Pair<BigInteger[], byte[]>[] getLog() {
 			throw new IllegalArgumentException("log not available in state " + this.getClass().getName());
 		}
@@ -609,7 +624,8 @@ public class DafnyEvm {
 			 *
 			 * @return
 			 */
-			public BigInteger getRemainingGas() {
+			@Override
+            public BigInteger getGas() {
 				return getEVM().dtor_gas();
 			}
 
@@ -736,7 +752,8 @@ public class DafnyEvm {
 				return DafnySequence.toByteArray(data);
 			}
 
-			public BigInteger getGasRefunded() {
+			@Override
+            public BigInteger getGas() {
 				return state.dtor_gas();
 			}
 		}
@@ -765,7 +782,8 @@ public class DafnyEvm {
 				return DafnySequence.toByteArray(data);
 			}
 
-			public BigInteger getGasRefunded() {
+			@Override
+            public BigInteger getGas() {
 				return state.dtor_gas();
 			}
 
@@ -796,7 +814,7 @@ public class DafnyEvm {
 			@Override
 			public String toString() {
 				String ws = toWorldStateString(getWorldState());
-				return "RETURN(gas=" + getGasRefunded() + "," + Hex.toHexString(getReturnData()) + "," + ws + ")";
+				return "RETURN(gas=" + getGas() + "," + Hex.toHexString(getReturnData()) + "," + ws + ")";
 			}
 		}
 
@@ -821,8 +839,8 @@ public class DafnyEvm {
 				return state._a0;
 			}
 
-			public BigInteger getGasUsed() {
-				// TODO: fixme!
+			@Override
+            public BigInteger getGas() {
 				return BigInteger.ZERO;
 			}
 

--- a/src/main/java/dafnyevm/util/Tracers.java
+++ b/src/main/java/dafnyevm/util/Tracers.java
@@ -83,7 +83,7 @@ public class Tracers {
 				JSONWriter obj = json.object();
 				obj.key("pc").value(state.getPC());
 				obj.key("op").value(state.getOpcode());
-				obj.key("gas").value(Hex.toHexString(state.getRemainingGas()));
+				obj.key("gas").value(Hex.toHexString(state.getGas()));
 				if (state.getMemorySize() > 0) {
 					byte[] mem = state.getMemory();
 					obj.key("memory").value(Hex.toHexString(mem));
@@ -105,7 +105,7 @@ public class Tracers {
 			try {
 				JSONWriter obj = json.object();
 				obj.key("output").value(Hex.toHexString(state.getReturnData()));
-				obj.key("gasUsed").value(Hex.toHexString(state.getGasRefunded()));
+				obj.key("gasUsed").value(Hex.toHexString(state.getGas()));
 				System.out.println(obj.endObject().toString());
 			} catch (JSONException e) {
 				// In principle, this should never happen!
@@ -119,7 +119,7 @@ public class Tracers {
 			try {
 				JSONWriter obj = json.object();
 				obj.key("output").value(Hex.toHexString(state.getReturnData()));
-				obj.key("gasUsed").value(Hex.toHexString(state.getGasRefunded()));
+				obj.key("gasUsed").value(Hex.toHexString(state.getGas()));
 				obj.key("error").value("execution reverted");
 				System.out.println(obj.endObject().toString());
 			} catch (JSONException e) {
@@ -133,7 +133,7 @@ public class Tracers {
 			JSONStringer json = new JSONStringer();
 			try {
 				JSONWriter obj = json.object();
-				obj.key("gasUsed").value(Hex.toHexString(state.getGasUsed()));
+				obj.key("gasUsed").value(Hex.toHexString(state.getGas()));
 				System.out.println(obj.endObject().toString());
 			} catch (JSONException e) {
 				// In principle, this should never happen!

--- a/src/test/java/dafnyevm/GeneralStateTests.java
+++ b/src/test/java/dafnyevm/GeneralStateTests.java
@@ -368,7 +368,7 @@ public class GeneralStateTests {
 			int pc = state.getPC().intValueExact();
 			int op = state.getOpcode();
 			int depth = state.getDepth();
-			long gas = state.getRemainingGas().longValueExact();
+			long gas = state.getGas().longValueExact();
 			// NOTE: to make traces equivalent with Geth we cannot appear to have "executed"
 			// the invalid bytecode.
 			if(op != Bytecodes.INVALID) {

--- a/src/test/java/dafnyevm/Tests.java
+++ b/src/test/java/dafnyevm/Tests.java
@@ -29,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static dafnyevm.DafnyEvm.DEFAULT_ORIGIN;
 import static dafnyevm.DafnyEvm.DEFAULT_RECEIVER;
+import static dafnyevm.DafnyEvm.DEFAULT_GAS;
 import dafnyevm.DafnyEvm.BlockInfo;
 import dafnyevm.DafnyEvm.State;
 import evmtools.util.Hex;
@@ -43,22 +44,22 @@ public class Tests {
 
 	@Test
 	public void test_stop_01() {
-		byte[] output = callWithReturn(new int[] { STOP });
+		byte[] output = callWithReturn(0, new int[] { STOP });
 		assertArrayEquals(new byte[0], output);
 	}
 
 	@Test
 	public void test_add_01() {
 		// 2 + 1 => 3
-		byte[] output = callWithReturn(
-				new int[] { PUSH1, 0x1, PUSH1, 0x2, ADD, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
+        byte[] output = callWithReturn(24,
+                new int[] { PUSH1, 0x1, PUSH1, 0x2, ADD, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x3), output);
 	}
 
 	@Test
 	public void test_sub_01() {
 		// 3 - 1 => 2
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(24,
 				new int[] { PUSH1, 0x1, PUSH1, 0x3, SUB, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x2), output);
 	}
@@ -66,7 +67,7 @@ public class Tests {
 	@Test
 	public void test_sub_02() {
 		// 0 - 6 => -6
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(24,
 				new int[] { PUSH1, 0x6, PUSH1, 0x0, SUB, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(not(UINT256(0x5)), output);
 	}
@@ -74,7 +75,7 @@ public class Tests {
 	@Test
 	public void test_mul_01() {
 		// 2 * 3 => 6
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(26,
 				new int[] { PUSH1, 0x3, PUSH1, 0x2, MUL, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x6), output);
 	}
@@ -82,7 +83,7 @@ public class Tests {
 	@Test
 	public void test_div_01() {
 		// 6 / 2 => 3
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(26,
 				new int[] { PUSH1, 0x2, PUSH1, 0x6, DIV, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x3), output);
 	}
@@ -90,7 +91,7 @@ public class Tests {
 	@Test
 	public void test_sdiv_01() {
 		// 6 / 2 => 3
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(26,
 				new int[] { PUSH1, 0x2, PUSH1, 0x6, SDIV, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x3), output);
 	}
@@ -98,15 +99,15 @@ public class Tests {
 	@Test
 	public void test_sdiv_02() {
 		// -6 / 2 => -3
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x2, PUSH1, 0x6, PUSH1, 0x0, SUB, SDIV, PUSH1, 0x00, MSTORE,
-				PUSH1, 0x20, PUSH1, 0x00, RETURN });
+		byte[] output = callWithReturn(32,
+		        new int[] { PUSH1, 0x2, PUSH1, 0x6, PUSH1, 0x0, SUB, SDIV, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(not(UINT256(0x2)), output);
 	}
 
 	@Test
 	public void test_sdiv_03() {
 		// -6 / -2 => 3
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x2, PUSH1, 0x0, SUB, PUSH1, 0x6, PUSH1, 0x0, SUB, SDIV,
+		byte[] output = callWithReturn(38,new int[] { PUSH1, 0x2, PUSH1, 0x0, SUB, PUSH1, 0x6, PUSH1, 0x0, SUB, SDIV,
 				PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x3), output);
 	}
@@ -114,7 +115,7 @@ public class Tests {
 	@Test
 	public void test_sdiv_04() {
 		// -6 / 4 => -1
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x4, PUSH1, 0x6, PUSH1, 0x0, SUB, SDIV, PUSH1, 0x00, MSTORE,
+		byte[] output = callWithReturn(32,new int[] { PUSH1, 0x4, PUSH1, 0x6, PUSH1, 0x0, SUB, SDIV, PUSH1, 0x00, MSTORE,
 				PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(not(UINT256(0x0)), output);
 	}
@@ -122,7 +123,7 @@ public class Tests {
 	@Test
 	public void test_mod_01() {
 		// 6 % 2 => 0
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(26,
 				new int[] { PUSH1, 0x2, PUSH1, 0x6, MOD, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x0), output);
 	}
@@ -130,7 +131,7 @@ public class Tests {
 	@Test
 	public void test_mod_02() {
 		// 6 % 4 => 2
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(26,
 				new int[] { PUSH1, 0x4, PUSH1, 0x6, MOD, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x02), output);
 	}
@@ -138,7 +139,7 @@ public class Tests {
 	@Test
 	public void test_smod_01() {
 		// 6 % 2 => 0
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(26,
 				new int[] { PUSH1, 0x2, PUSH1, 0x6, SMOD, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x0), output);
 	}
@@ -146,7 +147,7 @@ public class Tests {
 	@Test
 	public void test_smod_02() {
 		// 6 % 4 => 2
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(26,
 				new int[] { PUSH1, 0x4, PUSH1, 0x6, SMOD, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x02), output);
 	}
@@ -154,71 +155,71 @@ public class Tests {
 	@Test
 	public void test_smod_03() {
 		// -6 % 2 => 0
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x2, PUSH1, 0x6, PUSH1, 0x0, SUB, SMOD, PUSH1, 0x00, MSTORE,
-				PUSH1, 0x20, PUSH1, 0x00, RETURN });
+		byte[] output = callWithReturn(32,
+		        new int[] { PUSH1, 0x2, PUSH1, 0x6, PUSH1, 0x0, SUB, SMOD, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x0), output);
 	}
 
 	@Test
 	public void test_smod_04() {
 		// -6 % 4 => -2
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x4, PUSH1, 0x6, PUSH1, 0x0, SUB, SMOD, PUSH1, 0x00, MSTORE,
-				PUSH1, 0x20, PUSH1, 0x00, RETURN });
+		byte[] output = callWithReturn(32,
+		        new int[] { PUSH1, 0x4, PUSH1, 0x6, PUSH1, 0x0, SUB, SMOD, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(not(UINT256(0x01)), output);
 	}
 
 	@Test
 	public void test_smod_05() {
 		// -6 % -2 => 0
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x2, PUSH1, 0x0, SUB, PUSH1, 0x6, PUSH1, 0x0, SUB, SMOD,
-				PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
+		byte[] output = callWithReturn(38,
+		        new int[] { PUSH1, 0x2, PUSH1, 0x0, SUB, PUSH1, 0x6, PUSH1, 0x0, SUB, SMOD, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x0), output);
 	}
 
 	@Test
 	public void test_smod_06() {
 		// -6 % -4 => 0
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x2, PUSH1, 0x0, SUB, PUSH1, 0x6, PUSH1, 0x0, SUB, SMOD,
-				PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
+		byte[] output = callWithReturn(38,
+		        new int[] { PUSH1, 0x2, PUSH1, 0x0, SUB, PUSH1, 0x6, PUSH1, 0x0, SUB, SMOD, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x0), output);
 	}
 
 	@Test
 	public void test_addmod_01() {
 		// (2 + 1) % 8 => 3
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x8, PUSH1, 0x1, PUSH1, 0x2, ADDMOD, PUSH1, 0x00, MSTORE,
-				PUSH1, 0x20, PUSH1, 0x00, RETURN });
+		byte[] output = callWithReturn(32,
+		        new int[] { PUSH1, 0x8, PUSH1, 0x1, PUSH1, 0x2, ADDMOD, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x3), output);
 	}
 
 	@Test
 	public void test_addmod_02() {
 		// (5 + 1) % 4 => 2
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x4, PUSH1, 0x1, PUSH1, 0x5, ADDMOD, PUSH1, 0x00, MSTORE,
-				PUSH1, 0x20, PUSH1, 0x00, RETURN });
+		byte[] output = callWithReturn(32,
+		        new int[] { PUSH1, 0x4, PUSH1, 0x1, PUSH1, 0x5, ADDMOD, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x2), output);
 	}
 
 	@Test
 	public void test_mulmod_01() {
 		// (2 * 3) % 8 => 6
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x8, PUSH1, 0x3, PUSH1, 0x2, MULMOD, PUSH1, 0x00, MSTORE,
-				PUSH1, 0x20, PUSH1, 0x00, RETURN });
+		byte[] output = callWithReturn(32,
+		        new int[] { PUSH1, 0x8, PUSH1, 0x3, PUSH1, 0x2, MULMOD, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x6), output);
 	}
 
 	@Test
 	public void test_mulmod_02() {
 		// (2 * 3) % 4 => 2
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x4, PUSH1, 0x3, PUSH1, 0x2, MULMOD, PUSH1, 0x00, MSTORE,
-				PUSH1, 0x20, PUSH1, 0x00, RETURN });
+		byte[] output = callWithReturn(32,
+		        new int[] { PUSH1, 0x4, PUSH1, 0x3, PUSH1, 0x2, MULMOD, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x2), output);
 	}
 
 	@Test
 	public void test_exp_01() {
 		// 0^0 == 1
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(31,
 				new int[] { PUSH1, 0x0, PUSH1, 0x0, EXP, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x1), output);
 	}
@@ -226,7 +227,7 @@ public class Tests {
 	@Test
 	public void test_exp_02() {
 		// 2^0 == 1
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(31,
 				new int[] { PUSH1, 0x0, PUSH1, 0x2, EXP, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x1), output);
 	}
@@ -234,7 +235,7 @@ public class Tests {
 	@Test
 	public void test_exp_03() {
 		// 1^1 == 1
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(81,
 				new int[] { PUSH1, 0x1, PUSH1, 0x1, EXP, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x1), output);
 	}
@@ -242,7 +243,7 @@ public class Tests {
 	@Test
 	public void test_exp_04() {
 		// 2^1 == 2
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(81,
 				new int[] { PUSH1, 0x1, PUSH1, 0x2, EXP, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x2), output);
 	}
@@ -250,7 +251,7 @@ public class Tests {
 	@Test
 	public void test_exp_05() {
 		// 2^2 == 4
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(81,
 				new int[] { PUSH1, 0x2, PUSH1, 0x2, EXP, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x4), output);
 	}
@@ -258,7 +259,7 @@ public class Tests {
 	@Test
 	public void test_exp_06() {
 		// 2^3 == 8
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(81,
 				new int[] { PUSH1, 0x3, PUSH1, 0x2, EXP, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x8), output);
 	}
@@ -266,7 +267,7 @@ public class Tests {
 	@Test
 	public void test_exp_07() {
 		// 4^3 == 64
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(81,
 				new int[] { PUSH1, 0x3, PUSH1, 0x4, EXP, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x40), output);
 	}
@@ -274,16 +275,16 @@ public class Tests {
 	@Test
 	public void test_signextend_01() {
 		// extend 0x1 00001010 => 1111 ... 1111111100001010
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x0a, PUSH1, 0x0, SIGNEXTEND, PUSH1, 0x00, MSTORE, PUSH1,
-				0x20, PUSH1, 0x00, RETURN });
+		byte[] output = callWithReturn(26,
+		        new int[] { PUSH1, 0x0a, PUSH1, 0x0, SIGNEXTEND, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0xa), output);
 	}
 
 	@Test
 	public void test_signextend_02() {
 		// extend 0x1 00001010 => 1111 ... 1111111100001010
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x8a, PUSH1, 0x0, SIGNEXTEND, PUSH1, 0x00, MSTORE, PUSH1,
-				0x20, PUSH1, 0x00, RETURN });
+		byte[] output = callWithReturn(26,
+		        new int[] { PUSH1, 0x8a, PUSH1, 0x0, SIGNEXTEND, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(
 				toBytes(0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
 						0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x8a),
@@ -292,50 +293,50 @@ public class Tests {
 
 	@Test
 	public void test_signextend_03() {
-		byte[] output = callWithReturn(new int[] { PUSH3, 0x12, 0x2f, 0x6a, PUSH1, 0x0, SIGNEXTEND, PUSH1, 0x00, MSTORE,
-				PUSH1, 0x20, PUSH1, 0x00, RETURN });
+		byte[] output = callWithReturn(26,
+		        new int[] { PUSH3, 0x12, 0x2f, 0x6a, PUSH1, 0x0, SIGNEXTEND, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x6a), output);
 	}
 
 	@Test
 	public void test_signextend_04() {
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x8a, PUSH1, 0x1, SIGNEXTEND, PUSH1, 0x00, MSTORE, PUSH1,
-				0x20, PUSH1, 0x00, RETURN });
+		byte[] output = callWithReturn(26,
+		        new int[] { PUSH1, 0x8a, PUSH1, 0x1, SIGNEXTEND, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x8a), output);
 	}
 
 	@Test
 	public void test_signextend_05() {
-		byte[] output = callWithReturn(new int[] { PUSH2, 0x0f, 0x8a, PUSH1, 0x1, SIGNEXTEND, PUSH1, 0x00, MSTORE,
-				PUSH1, 0x20, PUSH1, 0x00, RETURN });
+		byte[] output = callWithReturn(26,
+		        new int[] { PUSH2, 0x0f, 0x8a, PUSH1, 0x1, SIGNEXTEND, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0xf8a), output);
 	}
 
 	@Test
 	public void test_signextend_06() {
-		byte[] output = callWithReturn(new int[] { PUSH2, 0x1f, 0x8a, PUSH1, 0x1, SIGNEXTEND, PUSH1, 0x00, MSTORE,
-				PUSH1, 0x20, PUSH1, 0x00, RETURN });
+		byte[] output = callWithReturn(26,
+		        new int[] { PUSH2, 0x1f, 0x8a, PUSH1, 0x1, SIGNEXTEND, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x1f8a), output);
 	}
 
 	@Test
 	public void test_signextend_07() {
-		byte[] output = callWithReturn(new int[] { PUSH2, 0x2f, 0x8a, PUSH1, 0x1, SIGNEXTEND, PUSH1, 0x00, MSTORE,
-				PUSH1, 0x20, PUSH1, 0x00, RETURN });
+		byte[] output = callWithReturn(26,
+		        new int[] { PUSH2, 0x2f, 0x8a, PUSH1, 0x1, SIGNEXTEND, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x2f8a), output);
 	}
 
 	@Test
 	public void test_signextend_08() {
-		byte[] output = callWithReturn(new int[] { PUSH2, 0x4f, 0x8a, PUSH1, 0x1, SIGNEXTEND, PUSH1, 0x00, MSTORE,
-				PUSH1, 0x20, PUSH1, 0x00, RETURN });
+		byte[] output = callWithReturn(26,
+		        new int[] { PUSH2, 0x4f, 0x8a, PUSH1, 0x1, SIGNEXTEND, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x4f8a), output);
 	}
 
 	@Test
 	public void test_signextend_09() {
-		byte[] output = callWithReturn(new int[] { PUSH2, 0x8f, 0x8a, PUSH1, 0x1, SIGNEXTEND, PUSH1, 0x00, MSTORE,
-				PUSH1, 0x20, PUSH1, 0x00, RETURN });
+		byte[] output = callWithReturn(26,
+		        new int[] { PUSH2, 0x8f, 0x8a, PUSH1, 0x1, SIGNEXTEND, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(
 				toBytes(0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
 						0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x8f, 0x8a),
@@ -349,7 +350,7 @@ public class Tests {
 	@Test
 	public void test_lt_01() {
 		// 2 < 1 = 0
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(24,
 				new int[] { PUSH1, 0x1, PUSH1, 0x2, LT, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x0), output);
 	}
@@ -357,7 +358,7 @@ public class Tests {
 	@Test
 	public void test_lt_02() {
 		// 1 < 2 = 1
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(24,
 				new int[] { PUSH1, 0x2, PUSH1, 0x1, LT, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x1), output);
 	}
@@ -365,7 +366,7 @@ public class Tests {
 	@Test
 	public void test_lt_03() {
 		// 2 < 2 => 0
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(24,
 				new int[] { PUSH1, 0x2, PUSH1, 0x2, LT, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x0), output);
 	}
@@ -373,7 +374,7 @@ public class Tests {
 	@Test
 	public void test_gt_01() {
 		// 2 > 1 => 1
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(24,
 				new int[] { PUSH1, 0x1, PUSH1, 0x2, GT, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x1), output);
 	}
@@ -381,7 +382,7 @@ public class Tests {
 	@Test
 	public void test_gt_02() {
 		// 1 > 2 => 0
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(24,
 				new int[] { PUSH1, 0x2, PUSH1, 0x1, GT, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x0), output);
 	}
@@ -389,7 +390,7 @@ public class Tests {
 	@Test
 	public void test_gt_03() {
 		// 2 > 2 => 0
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(24,
 				new int[] { PUSH1, 0x2, PUSH1, 0x2, GT, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x0), output);
 	}
@@ -397,7 +398,7 @@ public class Tests {
 	@Test
 	public void test_slt_01() {
 		// -2 < 1 => 1
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x1, PUSH1, 0x2, PUSH1, 0x0, SUB, SLT, PUSH1, 0x00, MSTORE,
+		byte[] output = callWithReturn(30,new int[] { PUSH1, 0x1, PUSH1, 0x2, PUSH1, 0x0, SUB, SLT, PUSH1, 0x00, MSTORE,
 				PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x1), output);
 	}
@@ -405,7 +406,7 @@ public class Tests {
 	@Test
 	public void test_slt_02() {
 		// 1 < -2 => 0
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x2, PUSH1, 0x0, SUB, PUSH1, 0x1, SLT, PUSH1, 0x00, MSTORE,
+		byte[] output = callWithReturn(30,new int[] { PUSH1, 0x2, PUSH1, 0x0, SUB, PUSH1, 0x1, SLT, PUSH1, 0x00, MSTORE,
 				PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x0), output);
 	}
@@ -413,7 +414,7 @@ public class Tests {
 	@Test
 	public void test_slt_03() {
 		// -2 < -1 => 1
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x1, PUSH1, 0x0, SUB, PUSH1, 0x2, PUSH1, 0x0, SUB, SLT, PUSH1,
+		byte[] output = callWithReturn(36,new int[] { PUSH1, 0x1, PUSH1, 0x0, SUB, PUSH1, 0x2, PUSH1, 0x0, SUB, SLT, PUSH1,
 				0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x1), output);
 	}
@@ -421,7 +422,7 @@ public class Tests {
 	@Test
 	public void test_slt_04() {
 		// -1 < -2 => 0
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x2, PUSH1, 0x0, SUB, PUSH1, 0x1, PUSH1, 0x0, SUB, SLT, PUSH1,
+		byte[] output = callWithReturn(36,new int[] { PUSH1, 0x2, PUSH1, 0x0, SUB, PUSH1, 0x1, PUSH1, 0x0, SUB, SLT, PUSH1,
 				0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x0), output);
 	}
@@ -429,7 +430,7 @@ public class Tests {
 	@Test
 	public void test_sgt_01() {
 		// -2 > 1 => 0
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x1, PUSH1, 0x2, PUSH1, 0x0, SUB, SGT, PUSH1, 0x00, MSTORE,
+		byte[] output = callWithReturn(30,new int[] { PUSH1, 0x1, PUSH1, 0x2, PUSH1, 0x0, SUB, SGT, PUSH1, 0x00, MSTORE,
 				PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x0), output);
 	}
@@ -437,7 +438,7 @@ public class Tests {
 	@Test
 	public void test_sgt_02() {
 		// 1 > -2 => 1
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x2, PUSH1, 0x0, SUB, PUSH1, 0x1, SGT, PUSH1, 0x00, MSTORE,
+		byte[] output = callWithReturn(30,new int[] { PUSH1, 0x2, PUSH1, 0x0, SUB, PUSH1, 0x1, SGT, PUSH1, 0x00, MSTORE,
 				PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x1), output);
 	}
@@ -445,7 +446,7 @@ public class Tests {
 	@Test
 	public void test_sgt_03() {
 		// -2 > -1 => 0
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x1, PUSH1, 0x0, SUB, PUSH1, 0x2, PUSH1, 0x0, SUB, SGT, PUSH1,
+		byte[] output = callWithReturn(36,new int[] { PUSH1, 0x1, PUSH1, 0x0, SUB, PUSH1, 0x2, PUSH1, 0x0, SUB, SGT, PUSH1,
 				0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x0), output);
 	}
@@ -453,7 +454,7 @@ public class Tests {
 	@Test
 	public void test_sgt_04() {
 		// -1 > -2 => 1
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x2, PUSH1, 0x0, SUB, PUSH1, 0x1, PUSH1, 0x0, SUB, SGT, PUSH1,
+		byte[] output = callWithReturn(36,new int[] { PUSH1, 0x2, PUSH1, 0x0, SUB, PUSH1, 0x1, PUSH1, 0x0, SUB, SGT, PUSH1,
 				0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x1), output);
 	}
@@ -461,7 +462,7 @@ public class Tests {
 	@Test
 	public void test_eq_01() {
 		// 2 = 1 => 0
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(24,
 				new int[] { PUSH1, 0x1, PUSH1, 0x2, EQ, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x0), output);
 	}
@@ -469,7 +470,7 @@ public class Tests {
 	@Test
 	public void test_eq_02() {
 		// 2 = 2 => 1
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(24,
 				new int[] { PUSH1, 0x2, PUSH1, 0x2, EQ, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x1), output);
 	}
@@ -477,7 +478,7 @@ public class Tests {
 	@Test
 	public void test_iszero_01() {
 		// 2 = 0 => 0
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(21,
 				new int[] { PUSH1, 0x2, ISZERO, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x0), output);
 	}
@@ -485,7 +486,7 @@ public class Tests {
 	@Test
 	public void test_iszero_02() {
 		// 0 = 0 => 1
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(21,
 				new int[] { PUSH1, 0x0, ISZERO, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x1), output);
 	}
@@ -493,7 +494,7 @@ public class Tests {
 	@Test
 	public void test_and_01() {
 		// 0b0001 & 0b0001 => 0b0001
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(24,
 				new int[] { PUSH1, 0b0001, PUSH1, 0b0001, AND, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0b0001), output);
 	}
@@ -501,7 +502,7 @@ public class Tests {
 	@Test
 	public void test_and_02() {
 		// 0b0001 & 0b0011 => 0b0001
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(24,
 				new int[] { PUSH1, 0b0011, PUSH1, 0b0001, AND, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0b0001), output);
 	}
@@ -509,7 +510,7 @@ public class Tests {
 	@Test
 	public void test_and_03() {
 		// 0b0101 & 0b0011 => 0b0001
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(24,
 				new int[] { PUSH1, 0b0011, PUSH1, 0b0101, AND, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0b0001), output);
 	}
@@ -517,7 +518,7 @@ public class Tests {
 	@Test
 	public void test_or_01() {
 		// 0b0001 | 0b0001 => 0b0001
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(24,
 				new int[] { PUSH1, 0b0001, PUSH1, 0b0001, OR, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0b0001), output);
 	}
@@ -525,7 +526,7 @@ public class Tests {
 	@Test
 	public void test_or_02() {
 		// 0b0001 | 0b0011 => 0b0011
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(24,
 				new int[] { PUSH1, 0b0011, PUSH1, 0b0001, OR, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0b0011), output);
 	}
@@ -533,7 +534,7 @@ public class Tests {
 	@Test
 	public void test_or_03() {
 		// 0b0101 | 0b0011 => 0b0111
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(24,
 				new int[] { PUSH1, 0b0011, PUSH1, 0b0101, OR, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0b0111), output);
 	}
@@ -541,7 +542,7 @@ public class Tests {
 	@Test
 	public void test_xor_01() {
 		// 0b0001 ^ 0b0001 => 0b0000
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(24,
 				new int[] { PUSH1, 0b0001, PUSH1, 0b0001, XOR, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0b0000), output);
 	}
@@ -549,7 +550,7 @@ public class Tests {
 	@Test
 	public void test_xor_02() {
 		// 0b0001 ^ 0b0011 => 0b0010
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(24,
 				new int[] { PUSH1, 0b0011, PUSH1, 0b0001, XOR, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0b0010), output);
 	}
@@ -557,7 +558,7 @@ public class Tests {
 	@Test
 	public void test_xor_03() {
 		// 0b0101 ^ 0b0011 => 0b0110
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(24,
 				new int[] { PUSH1, 0b0011, PUSH1, 0b0101, XOR, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0b0110), output);
 	}
@@ -565,7 +566,7 @@ public class Tests {
 	@Test
 	public void test_not_01() {
 		// ~0b00000101 => 0b11111010
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(21,
 				new int[] { PUSH1, 0b0101, NOT, PUSH1, 0x1F, MSTORE8, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0b11111010), output);
 	}
@@ -573,7 +574,7 @@ public class Tests {
 	@Test
 	public void test_not_02() {
 		// ~0b00000101 => 0b11111010
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(21,
 				new int[] { PUSH1, 0b0101, NOT, PUSH1, 0x0, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(not(UINT256(0b00000101)), output);
 	}
@@ -581,7 +582,7 @@ public class Tests {
 	@Test
 	public void test_byte_01() {
 		// Read byte 31 (0x1f) from 0x0102.
-		byte[] output = callWithReturn(new int[] { PUSH2, 0x01, 0x02, PUSH1, 0x1F, BYTE, PUSH1, 0x00, MSTORE, PUSH1,
+		byte[] output = callWithReturn(24,new int[] { PUSH2, 0x01, 0x02, PUSH1, 0x1F, BYTE, PUSH1, 0x00, MSTORE, PUSH1,
 				0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x02), output);
 	}
@@ -589,7 +590,7 @@ public class Tests {
 	@Test
 	public void test_byte_02() {
 		// Read byte 30 (0x1e) from 0x0102.
-		byte[] output = callWithReturn(new int[] { PUSH2, 0x01, 0x02, PUSH1, 0x1E, BYTE, PUSH1, 0x00, MSTORE, PUSH1,
+		byte[] output = callWithReturn(24,new int[] { PUSH2, 0x01, 0x02, PUSH1, 0x1E, BYTE, PUSH1, 0x00, MSTORE, PUSH1,
 				0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x01), output);
 	}
@@ -597,7 +598,7 @@ public class Tests {
 	@Test
 	public void test_shl_01() {
 		// 0xFE << 1 = 0x1FC
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(24,
 				new int[] { PUSH1, 0xFE, PUSH1, 0x1, SHL, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x1FC), output);
 	}
@@ -605,7 +606,7 @@ public class Tests {
 	@Test
 	public void test_shl_02() {
 		// 0xFE << 2 = 0x3F8
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(24,
 				new int[] { PUSH1, 0xFE, PUSH1, 0x2, SHL, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x3F8), output);
 	}
@@ -613,7 +614,7 @@ public class Tests {
 	@Test
 	public void test_shl_03() {
 		// 0xFE << 3 = 0x7F0
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(24,
 				new int[] { PUSH1, 0xFE, PUSH1, 0x3, SHL, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x7F0), output);
 	}
@@ -621,7 +622,7 @@ public class Tests {
 	@Test
 	public void test_shr_01() {
 		// 0x1FC >> 1 = 0xFE
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(24,
 				new int[] { PUSH2, 0x1, 0xFC, PUSH1, 0x1, SHR, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0xFE), output);
 	}
@@ -629,7 +630,7 @@ public class Tests {
 	@Test
 	public void test_shr_02() {
 		// 0x3F8 >> 2 = 0xFE
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(24,
 				new int[] { PUSH2, 0x3, 0xF8, PUSH1, 0x2, SHR, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0xFE), output);
 	}
@@ -637,7 +638,7 @@ public class Tests {
 	@Test
 	public void test_shr_03() {
 		// 0x7F0 >> 3 = 0xFE
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(24,
 				new int[] { PUSH2, 0x7, 0xF0, PUSH1, 0x3, SHR, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0xFE), output);
 	}
@@ -645,7 +646,7 @@ public class Tests {
 	@Test
 	public void test_sar_01() {
 		// (0 - 0x2) >> 1 = -0x1
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x2, PUSH1, 0x0, SUB, PUSH1, 0x1, SAR, PUSH1, 0x00, MSTORE,
+		byte[] output = callWithReturn(30,new int[] { PUSH1, 0x2, PUSH1, 0x0, SUB, PUSH1, 0x1, SAR, PUSH1, 0x00, MSTORE,
 				PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(INT256(-0x1), output);
 	}
@@ -653,7 +654,7 @@ public class Tests {
 	@Test
 	public void test_sar_02() {
 		// 0x1FC >> 1 = 0xFE
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(24,
 				new int[] { PUSH2, 0x1, 0xFC, PUSH1, 0x1, SAR, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0xFE), output);
 	}
@@ -661,7 +662,7 @@ public class Tests {
 	@Test
 	public void test_sar_03() {
 		// (0 - 0x1FC) >> 1 = -0xFE
-		byte[] output = callWithReturn(new int[] { PUSH2, 0x1, 0xFC, PUSH1, 0x0, SUB, PUSH1, 0x1, SAR, PUSH1, 0x00,
+		byte[] output = callWithReturn(30,new int[] { PUSH2, 0x1, 0xFC, PUSH1, 0x0, SUB, PUSH1, 0x1, SAR, PUSH1, 0x00,
 				MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(INT256(-0xFE), output);
 	}
@@ -669,7 +670,7 @@ public class Tests {
 	@Test
 	public void test_sar_04() {
 		// (0 - 0x3F8) >> 2 = -0xFE
-		byte[] output = callWithReturn(new int[] { PUSH2, 0x3, 0xF8, PUSH1, 0x0, SUB, PUSH1, 0x2, SAR, PUSH1, 0x00,
+		byte[] output = callWithReturn(30,new int[] { PUSH2, 0x3, 0xF8, PUSH1, 0x0, SUB, PUSH1, 0x2, SAR, PUSH1, 0x00,
 				MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(INT256(-0xFE), output);
 	}
@@ -677,7 +678,7 @@ public class Tests {
 	@Test
 	public void test_sar_05() {
 		// (0 - 0x7F0) >> 3 = -0xFE
-		byte[] output = callWithReturn(new int[] { PUSH2, 0x7, 0xF0, PUSH1, 0x0, SUB, PUSH1, 0x3, SAR, PUSH1, 0x00,
+		byte[] output = callWithReturn(30,new int[] { PUSH2, 0x7, 0xF0, PUSH1, 0x0, SUB, PUSH1, 0x3, SAR, PUSH1, 0x00,
 				MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(INT256(-0xFE), output);
 	}
@@ -685,7 +686,7 @@ public class Tests {
 	@Test
 	public void test_sar_06() {
 		// (0 - 0x5A) >> 1 = -0x2d
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x5A, PUSH1, 0x0, SUB, PUSH1, 0x1, SAR, PUSH1, 0x00,
+		byte[] output = callWithReturn(30,new int[] { PUSH1, 0x5A, PUSH1, 0x0, SUB, PUSH1, 0x1, SAR, PUSH1, 0x00,
 				MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(INT256(-0x2d), output);
 	}
@@ -693,7 +694,7 @@ public class Tests {
 	@Test
 	public void test_sar_07() {
 		// (0 - 0x5A) >> 2 = -0x17
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x5A, PUSH1, 0x0, SUB, PUSH1, 0x2, SAR, PUSH1, 0x00,
+		byte[] output = callWithReturn(30,new int[] { PUSH1, 0x5A, PUSH1, 0x0, SUB, PUSH1, 0x2, SAR, PUSH1, 0x00,
 				MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(INT256(-0x16), output);
 	}
@@ -701,7 +702,7 @@ public class Tests {
 	@Test
 	public void test_sar_08() {
 		// (0 - 0x5A) >> 3 = -0x0b
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x5A, PUSH1, 0x0, SUB, PUSH1, 0x3, SAR, PUSH1, 0x00,
+		byte[] output = callWithReturn(30,new int[] { PUSH1, 0x5A, PUSH1, 0x0, SUB, PUSH1, 0x3, SAR, PUSH1, 0x00,
 				MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(INT256(-0x0b), output);
 	}
@@ -713,7 +714,7 @@ public class Tests {
 	@Test
 	public void test_calldatasize_01() {
 		DafnyEvm tx = new DafnyEvm().sender(0);
-		byte[] output = callWithReturn(tx,
+		byte[] output = callWithReturn(17, tx,
 				new int[] { CALLDATASIZE, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x0), output);
 	}
@@ -721,7 +722,7 @@ public class Tests {
 	@Test
 	public void test_calldatasize_02() {
 		DafnyEvm tx = new DafnyEvm().sender(0).data(new byte[1]);
-		byte[] output = callWithReturn(tx,
+		byte[] output = callWithReturn(17, tx,
 				new int[] { CALLDATASIZE, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x1), output);
 	}
@@ -729,7 +730,7 @@ public class Tests {
 	@Test
 	public void test_calldatasize_03() {
 		DafnyEvm tx = new DafnyEvm().sender(0).data(new byte[7]);
-		byte[] output = callWithReturn(tx,
+		byte[] output = callWithReturn(17, tx,
 				new int[] { CALLDATASIZE, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x7), output);
 	}
@@ -737,7 +738,7 @@ public class Tests {
 	@Test
 	public void test_calldataload_01() {
 		DafnyEvm tx = new DafnyEvm().sender(0).data(UINT256(0xab4f7b));
-		byte[] output = callWithReturn(tx,
+		byte[] output = callWithReturn(21, tx,
 				new int[] { PUSH1, 0, CALLDATALOAD, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(output, UINT256(0xab4f7b));
 	}
@@ -747,7 +748,7 @@ public class Tests {
 		// Calldata has 31bytes, so CALLDATALOAD adds additional zero byte as lsb.
 		DafnyEvm tx = new DafnyEvm().sender(0).data(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x74 });
-		byte[] output = callWithReturn(tx,
+		byte[] output = callWithReturn(21, tx,
 				new int[] { PUSH1, 0, CALLDATALOAD, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(output, UINT256(0x7400));
 	}
@@ -757,7 +758,7 @@ public class Tests {
 		// Calldata has 31bytes, so CALLDATALOAD adds two additional zero bytes.
 		DafnyEvm tx = new DafnyEvm().sender(0).data(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x74 });
-		byte[] output = callWithReturn(tx,
+		byte[] output = callWithReturn(21, tx,
 				new int[] { PUSH1, 0, CALLDATALOAD, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(output, UINT256(0x740000));
 	}
@@ -766,7 +767,7 @@ public class Tests {
 	public void test_calldataload_04() {
 		// Read from non-zero offset in calldata (which results in padding)
 		DafnyEvm tx = new DafnyEvm().sender(0).data(UINT256(0xab4f7b));
-		byte[] output = callWithReturn(tx,
+		byte[] output = callWithReturn(21, tx,
 				new int[] { PUSH1, 1, CALLDATALOAD, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(output, UINT256(0xab4f7b00L));
 	}
@@ -775,7 +776,7 @@ public class Tests {
 	public void test_calldataload_05() {
 		// Load multiple items from calldata
 		DafnyEvm tx = new DafnyEvm().sender(0).data(append(UINT256(0xab4f7b), UINT256(0x7c4ead)));
-		byte[] output = callWithReturn(tx, new int[] { PUSH1, 0, CALLDATALOAD, PUSH1, 0x20, CALLDATALOAD, ADD, PUSH1,
+		byte[] output = callWithReturn(30, tx, new int[] { PUSH1, 0, CALLDATALOAD, PUSH1, 0x20, CALLDATALOAD, ADD, PUSH1,
 				0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(output, UINT256(0xab4f7b + 0x7c4ead));
 	}
@@ -784,7 +785,7 @@ public class Tests {
 	public void test_calldatacopy_01() {
 		// Copy call data into memory and return.
 		DafnyEvm tx = new DafnyEvm().sender(0).data(UINT256(0xab4f7b));
-		byte[] output = callWithReturn(tx,
+		byte[] output = callWithReturn(24, tx,
 				new int[] { PUSH1, 0x20, PUSH1, 0x0, PUSH1, 0x0, CALLDATACOPY, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(output, UINT256(0xab4f7b));
 	}
@@ -793,7 +794,7 @@ public class Tests {
 	public void test_calldatacopy_02() {
 		// Partially copy call data into memory and return.
 		DafnyEvm tx = new DafnyEvm().sender(0).data(UINT256(0xab4f7b));
-		byte[] output = callWithReturn(tx,
+		byte[] output = callWithReturn(24, tx,
 				new int[] { PUSH1, 0x1F, PUSH1, 0x0, PUSH1, 0x0, CALLDATACOPY, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(output, UINT256(0xab4f00));
 	}
@@ -802,7 +803,7 @@ public class Tests {
 	public void test_calldatacopy_03() {
 		// Copy call data into memory at non-zero offset and return.
 		DafnyEvm tx = new DafnyEvm().sender(0).data(new byte[] { 0x4f, 0x7b });
-		byte[] output = callWithReturn(tx,
+		byte[] output = callWithReturn(24, tx,
 				new int[] { PUSH1, 0x1, PUSH1, 0x1, PUSH1, 0x1F, CALLDATACOPY, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(output, UINT256(0x7b));
 	}
@@ -811,7 +812,7 @@ public class Tests {
 	public void test_calldatacopy_04() {
 		// Copy call data into memory at non-zero offset and return.
 		DafnyEvm tx = new DafnyEvm().sender(0).data(new byte[] { 0x4f, 0x7b });
-		byte[] output = callWithReturn(tx,
+		byte[] output = callWithReturn(24, tx,
 				new int[] { PUSH1, 0x1, PUSH1, 0x0, PUSH1, 0x1F, CALLDATACOPY, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(output, UINT256(0x4f));
 	}
@@ -820,7 +821,7 @@ public class Tests {
 	public void test_calldatacopy_05() {
 		// Copy call data into memory at non-zero offset and return.
 		DafnyEvm tx = new DafnyEvm().sender(0).data(new byte[] { 0x4f, 0x7b });
-		byte[] output = callWithReturn(tx,
+		byte[] output = callWithReturn(24, tx,
 				new int[] { PUSH1, 0x1, PUSH1, 0x1, PUSH1, 0x1E, CALLDATACOPY, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(output, UINT256(0x7b00));
 	}
@@ -829,7 +830,7 @@ public class Tests {
 	public void test_calldatacopy_06() {
 		// Copy call data into memory at non-zero offset and return.
 		DafnyEvm tx = new DafnyEvm().sender(0).data(new byte[] { 0x4f });
-		byte[] output = callWithReturn(tx,
+		byte[] output = callWithReturn(24, tx,
 				new int[] { PUSH1, 0x2, PUSH1, 0x0, PUSH1, 0x1E, CALLDATACOPY, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(output, UINT256(0x4f00));
 	}
@@ -837,14 +838,14 @@ public class Tests {
 	@Test
 	public void test_address_01() {
 		// Check address == DEFAULT_RECEIVER
-		byte[] output = callWithReturn(new int[] { ADDRESS, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
+		byte[] output = callWithReturn(17,new int[] { ADDRESS, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(DEFAULT_RECEIVER.intValueExact()), output);
 	}
 
 	@Test
 	public void test_selfbalance_01() {
 		// Transfer 10 Wei and check we can see it.
-		byte[] output = callWithReturn(new int[] { 0x47, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
+		byte[] output = callWithReturn(20,new int[] { 0x47, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0), output);
 	}
 
@@ -852,14 +853,14 @@ public class Tests {
 	public void test_selfbalance_02() {
 		// Transfer 10 Wei and check we can see it.
 		DafnyEvm tx = new DafnyEvm().value(BigInteger.TEN);
-		byte[] output = callWithReturn(tx, new int[] { 0x47, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
+		byte[] output = callWithReturn(20, tx, new int[] { 0x47, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(10), output);
 	}
 
 	@Test
 	public void test_balance_01() {
 		// Transfer 10 Wei and check we can see it.
-		byte[] output = callWithReturn(new int[] { ADDRESS, BALANCE, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
+		byte[] output = callWithReturn(117,new int[] { ADDRESS, BALANCE, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0), output);
 	}
 
@@ -867,49 +868,49 @@ public class Tests {
 	public void test_balance_02() {
 		// Transfer 10 Wei and check we can see it.
 		DafnyEvm tx = new DafnyEvm().value(BigInteger.TEN);
-		byte[] output = callWithReturn(tx, new int[] { ADDRESS, BALANCE, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
+		byte[] output = callWithReturn(117, tx, new int[] { ADDRESS, BALANCE, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(10), output);
 	}
 
 	@Test
 	public void test_origin_01() {
 		// Check origin == DEFAULT_ORIGIN
-		byte[] output = callWithReturn(new int[] { ORIGIN, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
+		byte[] output = callWithReturn(17,new int[] { ORIGIN, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(DEFAULT_ORIGIN.intValueExact()), output);
 	}
 
 	@Test
 	public void test_caller_01() {
 		// Check caller == DEFAULT_ORIGIN
-		byte[] output = callWithReturn(new int[] { CALLER, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
+		byte[] output = callWithReturn(17,new int[] { CALLER, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(DEFAULT_ORIGIN.intValueExact()), output);
 	}
 
 	@Test
 	public void test_callvalue_01() {
 		// Check callvalue == 0 (i.e. default)
-		byte[] output = callWithReturn(new int[] { CALLVALUE, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
+		byte[] output = callWithReturn(17,new int[] { CALLVALUE, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0), output);
 	}
 
 	@Test
 	public void test_callvalue_02() {
-		// Check callvalue == suplied value
+		// Check callvalue == supplied value
 		DafnyEvm tx = new DafnyEvm().value(BigInteger.TEN);
-		byte[] output = callWithReturn(tx,
+		byte[] output = callWithReturn(17, tx,
 				new int[] { CALLVALUE, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(10), output);
 	}
 
 	@Test
 	public void test_codesize_01() {
-		byte[] output = callWithReturn(new int[] { CODESIZE, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
+		byte[] output = callWithReturn(17,new int[] { CODESIZE, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(9), output);
 	}
 
 	@Test
 	public void test_codesize_02() {
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(22,
 				new int[] { CODESIZE, PUSH2, 0x00, 0x00, POP, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(13), output);
 	}
@@ -917,7 +918,7 @@ public class Tests {
 	@Test
 	public void test_codecopy_01() {
 		// Check can copy code (with padding)
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(24,
 				new int[] { PUSH1, 0x20, PUSH1, 0x00, PUSH1, 0x00, CODECOPY, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(Hex.toBytes("0x6020600060003960206000F30000000000000000000000000000000000000000"), output);
 	}
@@ -925,7 +926,7 @@ public class Tests {
 	@Test
 	public void test_codecopy_02() {
 		// Check can copy code (with padding)
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(24,
 				new int[] { PUSH1, 0x20, PUSH1, 0x01, PUSH1, 0x00, CODECOPY, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(Hex.toBytes("0x20600160003960206000F3000000000000000000000000000000000000000000"), output);
 	}
@@ -933,7 +934,7 @@ public class Tests {
 	@Test
 	public void test_codecopy_03() {
 		// Check can copy code (with padding)
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(27,
 				new int[] { PUSH1, 0x20, PUSH1, 0x00, PUSH1, 0x01, CODECOPY, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(Hex.toBytes("0x006020600060013960206000F300000000000000000000000000000000000000"), output);
 	}
@@ -941,7 +942,7 @@ public class Tests {
 	@Test
 	public void test_codecopy_04() {
 		// Check can copy code (with padding)
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(24,
 				new int[] { PUSH1, 0x08, PUSH1, 0x00, PUSH1, 0x00, CODECOPY, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(Hex.toBytes("0x6008600060003960000000000000000000000000000000000000000000000000"), output);
 	}
@@ -949,21 +950,21 @@ public class Tests {
 	@Test
 	public void test_gasprice_01() {
 		// Check gas price == 1
-		byte[] output = callWithReturn(new int[] { GASPRICE, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
+		byte[] output = callWithReturn(17,new int[] { GASPRICE, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(1), output);
 	}
 
 	@Test
 	public void test_extcodesize_01() {
 		DafnyEvm tx = new DafnyEvm().create(CONTRACT_1, toBytes(PUSH1, 0x20, PUSH1, 0x00, RETURN));
-		byte[] output = callWithReturn(tx, new int[] { PUSH2, 0xc, 0xcc, EXTCODESIZE, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
+		byte[] output = callWithReturn(2618, tx, new int[] { PUSH2, 0xc, 0xcc, EXTCODESIZE, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(5), output);
 	}
 
 	@Test
 	public void test_extcodecopy_01() {
 		// Check can copy code from non-existant contract.
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(2624,
 				new int[] { PUSH1, 0x20, PUSH1, 0x00, PUSH1, 0x00, PUSH2, 0x0c, 0xcc, EXTCODECOPY, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0), output);
 	}
@@ -971,7 +972,7 @@ public class Tests {
 	@Test
 	public void test_extcodecopy_02() {
 		DafnyEvm tx = new DafnyEvm().create(CONTRACT_1, toBytes(PUSH1, 0x20, PUSH1, 0x00, RETURN));
-		byte[] output = callWithReturn(tx,
+		byte[] output = callWithReturn(2624, tx,
 				new int[] { PUSH1, 0x05, PUSH1, 0x00, PUSH1, 0x00, PUSH2, 0x0c, 0xcc, EXTCODECOPY, PUSH1, 0x5, PUSH1, 0x00, RETURN });
 		assertArrayEquals(Hex.toBytes("0x60206000f3"), output);
 	}
@@ -980,7 +981,7 @@ public class Tests {
 	public void test_extcodecopy_03() {
 		// Test copy with padding
 		DafnyEvm tx = new DafnyEvm().create(CONTRACT_1, toBytes(PUSH1, 0x20, PUSH1, 0x00, RETURN));
-		byte[] output = callWithReturn(tx,
+		byte[] output = callWithReturn(2624, tx,
 				new int[] { PUSH1, 0x05, PUSH1, 0x00, PUSH1, 0x00, PUSH2, 0x0c, 0xcc, EXTCODECOPY, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(Hex.toBytes("0x60206000f3000000000000000000000000000000000000000000000000000000"), output);
 	}
@@ -989,7 +990,7 @@ public class Tests {
 	public void test_extcodecopy_04() {
 		// Test copy with padding
 		DafnyEvm tx = new DafnyEvm().create(CONTRACT_1, toBytes(PUSH1, 0x20, PUSH1, 0x00, RETURN));
-		byte[] output = callWithReturn(tx,
+		byte[] output = callWithReturn(2624, tx,
 				new int[] { PUSH1, 0x20, PUSH1, 0x00, PUSH1, 0x00, PUSH2, 0x0c, 0xcc, EXTCODECOPY, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(Hex.toBytes("0x60206000f3000000000000000000000000000000000000000000000000000000"), output);
 	}
@@ -998,14 +999,14 @@ public class Tests {
 	public void test_extcodehash_01() {
 		byte[] bytes = toBytes(PUSH1, 0x20, PUSH1, 0x00, RETURN);
 		DafnyEvm tx = new DafnyEvm().create(CONTRACT_1, bytes);
-		byte[] output = callWithReturn(tx, new int[] { PUSH2, 0xc, 0xcc, EXTCODEHASH, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
+		byte[] output = callWithReturn(2618, tx, new int[] { PUSH2, 0xc, 0xcc, EXTCODEHASH, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(Hash.sha3(bytes), output);
 	}
 
 	@Test
 	public void test_returndatasize_01() {
 		DafnyEvm tx = new DafnyEvm().sender(0);
-		byte[] output = callWithReturn(tx,
+		byte[] output = callWithReturn(17, tx,
 				new int[] { RETURNDATASIZE, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x0), output);
 	}
@@ -1014,7 +1015,7 @@ public class Tests {
 	public void test_returndatasize_02() {
 		// Contract call which returns 20 bytes of data.
 		DafnyEvm tx = new DafnyEvm().create(CONTRACT_1, toBytes(PUSH1, 0x20, PUSH1, 0x00, RETURN));
-		byte[] output = callWithReturn(tx, new int[] {
+		byte[] output = callWithReturn(2650, tx, new int[] {
 				// Make contract call to 0xccc with gas 0xffff, providing 32bytes for the return
 				// data at address 0.
 				PUSH1, 0x20, PUSH1, 0x00, DUP1, DUP1, DUP1, PUSH2, 0xc, 0xcc, PUSH2, 0xff, 0xff, CALL,
@@ -1030,7 +1031,7 @@ public class Tests {
 	public void test_returndatasize_03() {
 		// Contract call which returns 20 bytes of data, despite being asked for none.
 		DafnyEvm tx = new DafnyEvm().create(CONTRACT_1, toBytes(PUSH1, 0x20, PUSH1, 0x00, RETURN));
-		byte[] output = callWithReturn(tx, new int[] {
+		byte[] output = callWithReturn(2650, tx, new int[] {
 				// Make contract call to 0xccc with gas 0xffff, providing 32bytes for the return
 				// data at address 0.
 				PUSH1, 0x00, PUSH1, 0x00, DUP1, DUP1, DUP1, PUSH2, 0xc, 0xcc, PUSH2, 0xff, 0xff, CALL,
@@ -1046,7 +1047,7 @@ public class Tests {
 	public void test_returndatasize_04() {
 		// Contract call which returns 20 bytes of data, despite being asked for none.
 		DafnyEvm tx = new DafnyEvm().create(CONTRACT_1, toBytes(PUSH1, 0x20, PUSH1, 0x00, RETURN));
-		byte[] output = callWithReturn(tx, new int[] {
+		byte[] output = callWithReturn(2650, tx, new int[] {
 				// Make contract call to 0xccc with gas 0xffff, providing 32bytes for the return
 				// data at address 0.
 				PUSH1, 0x10, PUSH1, 0x00, DUP1, DUP1, DUP1, PUSH2, 0xc, 0xcc, PUSH2, 0xff, 0xff, CALL,
@@ -1062,7 +1063,7 @@ public class Tests {
 	public void test_returndatasize_05() {
 		// Contract call which returns 20 bytes of data, despite being asked for none.
 		DafnyEvm tx = new DafnyEvm().create(CONTRACT_1, toBytes(PUSH1, 0x20, PUSH1, 0x00, RETURN));
-		byte[] output = callWithReturn(tx, new int[] {
+		byte[] output = callWithReturn(2650, tx, new int[] {
 				// Make contract call to 0xccc with gas 0xffff, providing 32bytes for the return
 				// data at address 0.
 				PUSH1, 0x30, PUSH1, 0x00, DUP1, DUP1, DUP1, PUSH2, 0xc, 0xcc, PUSH2, 0xff, 0xff, CALL,
@@ -1086,7 +1087,7 @@ public class Tests {
 		//
 		DafnyEvm tx = new DafnyEvm().create(CONTRACT_1,
 				toBytes(PUSH2, 0x1, 0x23, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN));
-		byte[] output = callWithReturn(tx, new int[] {
+		byte[] output = callWithReturn(2666, tx, new int[] {
 				// Make contract call to 0xccc with gas 0xffff, providing 32bytes for the return
 				// data at address 0.
 				PUSH1, 0x20, PUSH1, 0x00, DUP1, DUP1, DUP1, PUSH2, 0xc, 0xcc, PUSH2, 0xff, 0xff, CALL,
@@ -1103,7 +1104,7 @@ public class Tests {
 		//
 		DafnyEvm tx = new DafnyEvm().create(CONTRACT_1,
 				toBytes(PUSH2, 0x1, 0x23, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN));
-		byte[] output = callWithReturn(tx, new int[] {
+		byte[] output = callWithReturn(2666, tx, new int[] {
 				// Make contract call to 0xccc with gas 0xffff, providing 32bytes for the return
 				// data at address 0.
 				PUSH1, 0x00, PUSH1, 0x00, DUP1, DUP1, DUP1, PUSH2, 0xc, 0xcc, PUSH2, 0xff, 0xff, CALL,
@@ -1122,7 +1123,7 @@ public class Tests {
 	@Test
 	public void test_coinbase_01() {
 		DafnyEvm tx = new DafnyEvm().blockInfo(new BlockInfo().coinBase(0xcccc));
-		byte[] output = callWithReturn(tx,
+		byte[] output = callWithReturn(17, tx,
 				new int[] { COINBASE, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0xcccc), output);
 	}
@@ -1130,7 +1131,7 @@ public class Tests {
 	@Test
 	public void test_timestamp_01() {
 		DafnyEvm tx = new DafnyEvm().blockInfo(new BlockInfo().timeStamp(0xcccc));
-		byte[] output = callWithReturn(tx,
+		byte[] output = callWithReturn(17, tx,
 				new int[] { TIMESTAMP, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0xcccc), output);
 	}
@@ -1138,14 +1139,14 @@ public class Tests {
 	@Test
 	public void test_number_01() {
 		DafnyEvm tx = new DafnyEvm().blockInfo(new BlockInfo().number(0xcccc));
-		byte[] output = callWithReturn(tx, new int[] { NUMBER, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
+		byte[] output = callWithReturn(17, tx, new int[] { NUMBER, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0xcccc), output);
 	}
 
 	@Test
 	public void test_difficulty_01() {
 		DafnyEvm tx = new DafnyEvm().blockInfo(new BlockInfo().difficulty(0xcccc));
-		byte[] output = callWithReturn(tx,
+		byte[] output = callWithReturn(17, tx,
 				new int[] { DIFFICULTY, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0xcccc), output);
 	}
@@ -1153,7 +1154,7 @@ public class Tests {
 	@Test
 	public void test_gaslimit_01() {
 		DafnyEvm tx = new DafnyEvm().blockInfo(new BlockInfo().gasLimit(0xcccc));
-		byte[] output = callWithReturn(tx,
+		byte[] output = callWithReturn(17, tx,
 				new int[] { GASLIMIT, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0xcccc), output);
 	}
@@ -1161,7 +1162,7 @@ public class Tests {
 	@Test
 	public void test_chainid_01() {
 		DafnyEvm tx = new DafnyEvm().blockInfo(new BlockInfo().chainID(0xcccc));
-		byte[] output = callWithReturn(tx,
+		byte[] output = callWithReturn(17, tx,
 				new int[] { CHAINID, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0xcccc), output);
 	}
@@ -1172,7 +1173,7 @@ public class Tests {
 
 	@Test
 	public void test_pop_01() {
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x02, PUSH1, 0x01, POP, PUSH1, 0x00, RETURN });
+		byte[] output = callWithReturn(14,new int[] { PUSH1, 0x02, PUSH1, 0x01, POP, PUSH1, 0x00, RETURN });
 		assertArrayEquals(new byte[] { 0, 0 }, output);
 	}
 
@@ -1185,14 +1186,14 @@ public class Tests {
 	@Test
 	public void test_mstore_01() {
 		// Check words stored in big endian format.
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x7b, PUSH1, 0x00, MSTORE, PUSH1, 0x1, PUSH1, 0x00, RETURN });
+		byte[] output = callWithReturn(18,new int[] { PUSH1, 0x7b, PUSH1, 0x00, MSTORE, PUSH1, 0x1, PUSH1, 0x00, RETURN });
 		assertArrayEquals(new byte[] { 0 }, output);
 	}
 
 	@Test
 	public void test_mstore_02() {
 		// Check can return data from memory.
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(18,
 				new int[] { PUSH1, 0x7b, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x7b), output);
 	}
@@ -1200,7 +1201,7 @@ public class Tests {
 	@Test
 	public void test_mstore_03() {
 		// Check can return data from memory.
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(18,
 				new int[] { PUSH2, 0x4d, 0x7b, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x4d7b), output);
 	}
@@ -1208,39 +1209,39 @@ public class Tests {
 	@Test
 	public void test_mstore_04() {
 		// Check memory expansion from mstore
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x15, PUSH1, 31, MSTORE, MSIZE, PUSH1, 0x00, MSTORE, PUSH1,
-				0x20, PUSH1, 0x0, RETURN });
+		byte[] output = callWithReturn(29,
+		        new int[] { PUSH1, 0x15, PUSH1, 31, MSTORE, MSIZE, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x0, RETURN });
 		assertArrayEquals(UINT256(0x40), output);
 	}
 
 	@Test
 	public void test_mstore_05() {
 		// Check memory expansion from mstore
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x7F, PUSH1, 31, MSTORE, MSIZE, PUSH1, 0x00, MSTORE, PUSH1,
-				0x20, PUSH1, 0x0, RETURN });
+		byte[] output = callWithReturn(29,
+		        new int[] { PUSH1, 0x7F, PUSH1, 31, MSTORE, MSIZE, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x0, RETURN });
 		assertArrayEquals(UINT256(0x40), output);
 	}
 
 	@Test
 	public void test_mstore_06() {
 		// Check memory expansion from mstore
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x7F, PUSH1, 32, MSTORE, MSIZE, PUSH1, 0x00, MSTORE, PUSH1,
-				0x20, PUSH1, 0x0, RETURN });
+		byte[] output = callWithReturn(29,
+		        new int[] { PUSH1, 0x7F, PUSH1, 32, MSTORE, MSIZE, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x0, RETURN });
 		assertArrayEquals(UINT256(0x40), output);
 	}
 
 	@Test
 	public void test_mstore_07() {
 		// Check memory expansion from mstore
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x7F, PUSH1, 33, MSTORE, MSIZE, PUSH1, 0x00, MSTORE, PUSH1,
-				0x20, PUSH1, 0x0, RETURN });
+		byte[] output = callWithReturn(32,
+		        new int[] { PUSH1, 0x7F, PUSH1, 33, MSTORE, MSIZE, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x0, RETURN });
 		assertArrayEquals(UINT256(0x60), output);
 	}
 
 	@Test
 	public void test_mload_01() {
 		// Check can read and write data to memory
-		byte[] output = callWithReturn(new int[] { PUSH2, 0x4d, 0x7b, PUSH1, 0x00, MSTORE, PUSH1, 0x00, MLOAD, PUSH1,
+		byte[] output = callWithReturn(33,new int[] { PUSH2, 0x4d, 0x7b, PUSH1, 0x00, MSTORE, PUSH1, 0x00, MLOAD, PUSH1,
 				0x20, MSTORE, PUSH1, 0x20, PUSH1, 0x20, RETURN });
 		assertArrayEquals(UINT256(0x4d7b), output);
 	}
@@ -1248,7 +1249,7 @@ public class Tests {
 	@Test
 	public void test_mload_02() {
 		// Check memory expansion from mload
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(25,
 				new int[] { PUSH1, 0, MLOAD, POP, MSIZE, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x0, RETURN });
 		assertArrayEquals(UINT256(0x20), output);
 	}
@@ -1256,7 +1257,7 @@ public class Tests {
 	@Test
 	public void test_mload_03() {
 		// Check memory expansion from mload
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(28,
 				new int[] { PUSH1, 15, MLOAD, POP, MSIZE, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x0, RETURN });
 		assertArrayEquals(UINT256(0x40), output);
 	}
@@ -1264,7 +1265,7 @@ public class Tests {
 	@Test
 	public void test_mload_04() {
 		// Check memory expansion from mload
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(28,
 				new int[] { PUSH1, 31, MLOAD, POP, MSIZE, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x0, RETURN });
 		assertArrayEquals(UINT256(0x40), output);
 	}
@@ -1272,7 +1273,7 @@ public class Tests {
 	@Test
 	public void test_mload_05() {
 		// Check memory expansion from mload
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(26,
 				new int[] { PUSH1, 32, MLOAD, MSIZE, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x0, RETURN });
 		assertArrayEquals(UINT256(0x40), output);
 	}
@@ -1280,7 +1281,7 @@ public class Tests {
 	@Test
 	public void test_mstore8_01() {
 		// Check words stored in big endian format.
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(18,
 				new int[] { PUSH1, 0x7b, PUSH1, 0x00, MSTORE8, PUSH1, 0x1, PUSH1, 0x00, RETURN });
 		assertArrayEquals(new byte[] { 0x7b }, output);
 	}
@@ -1288,7 +1289,7 @@ public class Tests {
 	@Test
 	public void test_mstore8_02() {
 		// Check can return data from memory.
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(18,
 				new int[] { PUSH1, 0x7b, PUSH1, 0x00, MSTORE8, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(shl(UINT256(0x7b), 31), output);
 	}
@@ -1296,7 +1297,7 @@ public class Tests {
 	@Test
 	public void test_mstore8_03() {
 		// Check can return data from memory.
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(18,
 				new int[] { PUSH2, 0x4d, 0x7b, PUSH1, 0x00, MSTORE8, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(shl(UINT256(0x7b), 31), output);
 	}
@@ -1304,13 +1305,13 @@ public class Tests {
 	@Test
 	public void test_sstore_01() {
 		// test add11 from the reference tests
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x1, PUSH1, 0x1, ADD, PUSH1, 0x00, SSTORE, STOP });
+		byte[] output = callWithReturn(22112, new int[] { PUSH1, 0x1, PUSH1, 0x1, ADD, PUSH1, 0x00, SSTORE, STOP });
 		assertArrayEquals(new byte[0], output);
 	}
 
 	@Test
 	public void test_sstore_02() {
-		byte[] output = callWithReturn(new int[] { PUSH2, 0x4d, 0x7b, PUSH1, 0x00, SSTORE, PUSH1, 0x00, SLOAD, PUSH1,
+		byte[] output = callWithReturn(22224, new int[] { PUSH2, 0x4d, 0x7b, PUSH1, 0x00, SSTORE, PUSH1, 0x00, SLOAD, PUSH1,
 				0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x4d7b), output);
 	}
@@ -1318,7 +1319,7 @@ public class Tests {
 	@Test
 	public void test_jump_01() {
 		// Branch over invalid
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x4, JUMP, INVALID, JUMPDEST, STOP });
+		byte[] output = callWithReturn(12,new int[] { PUSH1, 0x4, JUMP, INVALID, JUMPDEST, STOP });
 		assertArrayEquals(new byte[0], output);
 	}
 
@@ -1337,21 +1338,24 @@ public class Tests {
 	@Test
 	public void test_jumpi_01() {
 		// Condition branch (taken) over invalid
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x01, PUSH1, 0x6, JUMPI, INVALID, JUMPDEST, STOP });
+		byte[] output = callWithReturn(17,
+		        new int[] { PUSH1, 0x01, PUSH1, 0x6, JUMPI, INVALID, JUMPDEST, STOP });
 		assertArrayEquals(new byte[0], output);
 	}
 
 	@Test
 	public void test_jumpi_02() {
 		// Condition branch (not taken) avoids invalid
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x00, PUSH1, 0x6, JUMPI, STOP, JUMPDEST, INVALID });
+		byte[] output = callWithReturn(16,
+		        new int[] { PUSH1, 0x00, PUSH1, 0x6, JUMPI, STOP, JUMPDEST, INVALID });
 		assertArrayEquals(new byte[0], output);
 	}
 
 	@Test
 	public void test_jumpi_03() {
 		// Condition branch (not taken) doesn't require JUMPDEST.
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x00, PUSH1, 0x6, JUMPI, STOP });
+		byte[] output = callWithReturn(16,
+		        new int[] { PUSH1, 0x00, PUSH1, 0x6, JUMPI, STOP });
 		assertArrayEquals(new byte[0], output);
 	}
 
@@ -1370,14 +1374,14 @@ public class Tests {
 	@Test
 	public void test_pc_01() {
 		// PC = 0
-		byte[] output = callWithReturn(new int[] { PC, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
+		byte[] output = callWithReturn(17,new int[] { PC, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x0), output);
 	}
 
 	@Test
 	public void test_pc_02() {
 		// PC = 1
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(18,
 				new int[] { JUMPDEST, PC, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x1), output);
 	}
@@ -1385,7 +1389,7 @@ public class Tests {
 	@Test
 	public void test_pc_03() {
 		// PC = 2
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(20,
 				new int[] { PUSH1, 0x1, PC, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x2), output);
 	}
@@ -1393,44 +1397,44 @@ public class Tests {
 	@Test
 	public void test_msize_01() {
 		// Check memory expansion from mload
-		byte[] output = callWithReturn(new int[] { MSIZE, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x20, RETURN });
+		byte[] output = callWithReturn(20,new int[] { MSIZE, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x20, RETURN });
 		assertArrayEquals(UINT256(0x0), output);
 	}
 
 	@Test
 	public void test_gas_01() {
 		// Check cost of GAS bytecode.
-		byte[] output = callWithReturn(new int[] { GAS, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
-		assertArrayEquals(UINT256(DafnyEvm.DEFAULT_GAS.longValueExact() - 2), output);
+		byte[] output = callWithReturn(17, new int[] { GAS, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
+		assertArrayEquals(UINT256(DEFAULT_GAS.longValueExact() - 2), output);
 	}
 
 	@Test
 	public void test_gas_02() {
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(20,
 				new int[] { PUSH1, 0x00, GAS, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
-		assertArrayEquals(UINT256(DafnyEvm.DEFAULT_GAS.longValueExact() - 5), output);
+		assertArrayEquals(UINT256(DEFAULT_GAS.longValueExact() - 5), output);
 	}
 
 	@Test
 	public void test_gas_03() {
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(22,
 				new int[] { PUSH1, 0x00, POP, GAS, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
-		assertArrayEquals(UINT256(DafnyEvm.DEFAULT_GAS.longValueExact() - 7), output);
+		assertArrayEquals(UINT256(DEFAULT_GAS.longValueExact() - 7), output);
 	}
 
 	@Test
 	public void test_gas_04() {
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x01, PUSH1, 0x0, MSTORE, GAS, PUSH1, 0x00, MSTORE, PUSH1,
-				0x20, PUSH1, 0x00, RETURN });
-		assertArrayEquals(UINT256(DafnyEvm.DEFAULT_GAS.longValueExact() - 14), output);
+		byte[] output = callWithReturn(26,
+		        new int[] { PUSH1, 0x01, PUSH1, 0x0, MSTORE, GAS, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
+		assertArrayEquals(UINT256(DEFAULT_GAS.longValueExact() - 14), output);
 	}
 
 	@Test
 	public void test_gas_05() {
 		// 3 + 3 + 3 + (3 * 3) + 2
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x01, PUSH1, 0x40, MSTORE, GAS, PUSH1, 0x00, MSTORE, PUSH1,
-				0x20, PUSH1, 0x00, RETURN });
-		assertArrayEquals(UINT256(DafnyEvm.DEFAULT_GAS.longValueExact() - 20), output);
+		byte[] output = callWithReturn(32,
+		        new int[] { PUSH1, 0x01, PUSH1, 0x40, MSTORE, GAS, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
+		assertArrayEquals(UINT256(DEFAULT_GAS.longValueExact() - 20), output);
 	}
 
 	@Test
@@ -1439,24 +1443,23 @@ public class Tests {
 		// (513 * 513) / 512 = 514
 		// -------------------------------
 		// 3 + 3 + 3 + (3 * 513 + 514) + 2
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x01, PUSH2, 0x40, 0x00, MSTORE, GAS, PUSH1, 0x00, MSTORE,
-				PUSH1, 0x20, PUSH1, 0x00, RETURN });
-		assertArrayEquals(UINT256(DafnyEvm.DEFAULT_GAS.longValueExact() - 2064), output);
+		byte[] output = callWithReturn(2076,new int[] { PUSH1, 0x01, PUSH2, 0x40, 0x00, MSTORE, GAS, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
+		assertArrayEquals(UINT256(DEFAULT_GAS.longValueExact() - 2064), output);
 	}
 
 	@Test
 	public void test_gas_07() {
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x01, PUSH1, 0x0, MLOAD, GAS, PUSH1, 0x00, MSTORE, PUSH1,
+		byte[] output = callWithReturn(26,new int[] { PUSH1, 0x01, PUSH1, 0x0, MLOAD, GAS, PUSH1, 0x00, MSTORE, PUSH1,
 				0x20, PUSH1, 0x00, RETURN });
-		assertArrayEquals(UINT256(DafnyEvm.DEFAULT_GAS.longValueExact() - 14), output);
+		assertArrayEquals(UINT256(DEFAULT_GAS.longValueExact() - 14), output);
 	}
 
 	@Test
 	public void test_gas_08() {
 		// 3 + 3 + 3 + (3 * 3) + 2
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x01, PUSH1, 0x40, MLOAD, GAS, PUSH1, 0x00, MSTORE, PUSH1,
+		byte[] output = callWithReturn(32,new int[] { PUSH1, 0x01, PUSH1, 0x40, MLOAD, GAS, PUSH1, 0x00, MSTORE, PUSH1,
 				0x20, PUSH1, 0x00, RETURN });
-		assertArrayEquals(UINT256(DafnyEvm.DEFAULT_GAS.longValueExact() - 20), output);
+		assertArrayEquals(UINT256(DEFAULT_GAS.longValueExact() - 20), output);
 	}
 
 	@Test
@@ -1465,9 +1468,9 @@ public class Tests {
 		// (513 * 513) / 512 = 514
 		// -------------------------------
 		// 3 + 3 + 3 + (3 * 513 + 514) + 2
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x01, PUSH2, 0x40, 0x00, MLOAD, GAS, PUSH1, 0x00, MSTORE,
+		byte[] output = callWithReturn(2076,new int[] { PUSH1, 0x01, PUSH2, 0x40, 0x00, MLOAD, GAS, PUSH1, 0x00, MSTORE,
 				PUSH1, 0x20, PUSH1, 0x00, RETURN });
-		assertArrayEquals(UINT256(DafnyEvm.DEFAULT_GAS.longValueExact() - 2064), output);
+		assertArrayEquals(UINT256(DEFAULT_GAS.longValueExact() - 2064), output);
 	}
 
 	// ========================================================================
@@ -1476,180 +1479,180 @@ public class Tests {
 
 	@Test
 	public void test_push1_01() {
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x00, PUSH1, 0x00, RETURN });
+		byte[] output = callWithReturn(6, new int[] { PUSH1, 0x00, PUSH1, 0x00, RETURN });
 		assertArrayEquals(new byte[0], output);
 	}
 
 	@Test
 	public void test_push1_02() {
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x01, PUSH1, 0x00, RETURN });
+		byte[] output = callWithReturn(9, new int[] { PUSH1, 0x01, PUSH1, 0x00, RETURN });
 		assertArrayEquals(new byte[] { 0 }, output);
 	}
 
 	@Test
 	public void test_push1_03() {
-		byte[] output = callWithReturn(new int[] { PUSH1 });
+		byte[] output = callWithReturn(3, new int[] { PUSH1 });
 		assertArrayEquals(new byte[0], output);
 	}
 
 	@Test
 	public void test_push2_01() {
-		byte[] output = callWithReturn(new int[] { PUSH2, 0x00, 0x02, PUSH1, 0x00, RETURN });
+		byte[] output = callWithReturn(9, new int[] { PUSH2, 0x00, 0x02, PUSH1, 0x00, RETURN });
 		assertArrayEquals(new byte[] { 0, 0 }, output);
 	}
 
 	@Test
 	public void test_push2_02() {
-		byte[] output = callWithReturn(new int[] { PUSH2 });
+		byte[] output = callWithReturn(3, new int[] { PUSH2 });
 		assertArrayEquals(new byte[0], output);
 	}
 
 	@Test
 	public void test_push3_01() {
-		byte[] output = callWithReturn(new int[] { PUSH3, 0x00, 0x00, 0x03, PUSH1, 0x00, RETURN });
+		byte[] output = callWithReturn(9, new int[] { PUSH3, 0x00, 0x00, 0x03, PUSH1, 0x00, RETURN });
 		assertArrayEquals(new byte[] { 0, 0, 0 }, output);
 	}
 
 	@Test
 	public void test_push4_01() {
-		byte[] output = callWithReturn(new int[] { PUSH4, 0x00, 0x00, 0x00, 0x04, PUSH1, 0x00, RETURN });
+		byte[] output = callWithReturn(9, new int[] { PUSH4, 0x00, 0x00, 0x00, 0x04, PUSH1, 0x00, RETURN });
 		assertArrayEquals(new byte[] { 0, 0, 0, 0 }, output);
 	}
 
 	@Test
 	public void test_push5_01() {
-		byte[] output = callWithReturn(new int[] { PUSH5, 0x00, 0x00, 0x00, 0x00, 0x05, PUSH1, 0x00, RETURN });
+		byte[] output = callWithReturn(9, new int[] { PUSH5, 0x00, 0x00, 0x00, 0x00, 0x05, PUSH1, 0x00, RETURN });
 		assertArrayEquals(new byte[] { 0, 0, 0, 0, 0 }, output);
 	}
 
 	@Test
 	public void test_push6_01() {
-		byte[] output = callWithReturn(new int[] { PUSH6, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, PUSH1, 0x00, RETURN });
+		byte[] output = callWithReturn(9, new int[] { PUSH6, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, PUSH1, 0x00, RETURN });
 		assertArrayEquals(new byte[] { 0, 0 }, output);
 	}
 
 	@Test
 	public void test_push7_01() {
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(9,
 				new int[] { PUSH7, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, PUSH1, 0x00, RETURN });
 		assertArrayEquals(new byte[] { 0, 0 }, output);
 	}
 
 	@Test
 	public void test_push8_01() {
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(9,
 				new int[] { PUSH8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, PUSH1, 0x00, RETURN });
 		assertArrayEquals(new byte[] { 0, 0 }, output);
 	}
 
 	@Test
 	public void test_push9_01() {
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(9,
 				new int[] { PUSH9, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, PUSH1, 0x00, RETURN });
 		assertArrayEquals(new byte[] { 0, 0 }, output);
 	}
 
 	@Test
 	public void test_push10_01() {
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(9,
 				new int[] { PUSH10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, PUSH1, 0x00, RETURN });
 		assertArrayEquals(new byte[] { 0, 0 }, output);
 	}
 
 	@Test
 	public void test_push11_01() {
-		byte[] output = callWithReturn(new int[] { PUSH11, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		byte[] output = callWithReturn(9, new int[] { PUSH11, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 				0x02, PUSH1, 0x00, RETURN });
 		assertArrayEquals(new byte[] { 0, 0 }, output);
 	}
 
 	@Test
 	public void test_push12_01() {
-		byte[] output = callWithReturn(new int[] { PUSH12, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		byte[] output = callWithReturn(9, new int[] { PUSH12, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 				0x00, 0x02, PUSH1, 0x00, RETURN });
 		assertArrayEquals(new byte[] { 0, 0 }, output);
 	}
 
 	@Test
 	public void test_push13_01() {
-		byte[] output = callWithReturn(new int[] { PUSH13, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		byte[] output = callWithReturn(9, new int[] { PUSH13, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 				0x00, 0x00, 0x02, PUSH1, 0x00, RETURN });
 		assertArrayEquals(new byte[] { 0, 0 }, output);
 	}
 
 	@Test
 	public void test_push14_01() {
-		byte[] output = callWithReturn(new int[] { PUSH14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		byte[] output = callWithReturn(9, new int[] { PUSH14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 				0x00, 0x00, 0x00, 0x02, PUSH1, 0x00, RETURN });
 		assertArrayEquals(new byte[] { 0, 0 }, output);
 	}
 
 	@Test
 	public void test_push15_01() {
-		byte[] output = callWithReturn(new int[] { PUSH15, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		byte[] output = callWithReturn(9, new int[] { PUSH15, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 				0x00, 0x00, 0x00, 0x00, 0x02, PUSH1, 0x00, RETURN });
 		assertArrayEquals(new byte[] { 0, 0 }, output);
 	}
 
 	@Test
 	public void test_push16_01() {
-		byte[] output = callWithReturn(new int[] { PUSH16, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		byte[] output = callWithReturn(9, new int[] { PUSH16, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 				0x00, 0x00, 0x00, 0x00, 0x00, 0x02, PUSH1, 0x00, RETURN });
 		assertArrayEquals(new byte[] { 0, 0 }, output);
 	}
 
 	@Test
 	public void test_push17_01() {
-		byte[] output = callWithReturn(new int[] { PUSH17, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		byte[] output = callWithReturn(9, new int[] { PUSH17, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, PUSH1, 0x00, RETURN });
 		assertArrayEquals(new byte[] { 0, 0 }, output);
 	}
 
 	@Test
 	public void test_push18_01() {
-		byte[] output = callWithReturn(new int[] { PUSH18, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		byte[] output = callWithReturn(9, new int[] { PUSH18, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, PUSH1, 0x00, RETURN });
 		assertArrayEquals(new byte[] { 0, 0 }, output);
 	}
 
 	@Test
 	public void test_push19_01() {
-		byte[] output = callWithReturn(new int[] { PUSH19, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		byte[] output = callWithReturn(9, new int[] { PUSH19, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, PUSH1, 0x00, RETURN });
 		assertArrayEquals(new byte[] { 0, 0 }, output);
 	}
 
 	@Test
 	public void test_push20_01() {
-		byte[] output = callWithReturn(new int[] { PUSH20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		byte[] output = callWithReturn(9, new int[] { PUSH20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, PUSH1, 0x00, RETURN });
 		assertArrayEquals(new byte[] { 0, 0 }, output);
 	}
 
 	@Test
 	public void test_push21_01() {
-		byte[] output = callWithReturn(new int[] { PUSH21, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		byte[] output = callWithReturn(9, new int[] { PUSH21, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, PUSH1, 0x00, RETURN });
 		assertArrayEquals(new byte[] { 0, 0 }, output);
 	}
 
 	@Test
 	public void test_push22_01() {
-		byte[] output = callWithReturn(new int[] { PUSH22, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		byte[] output = callWithReturn(9, new int[] { PUSH22, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, PUSH1, 0x00, RETURN });
 		assertArrayEquals(new byte[] { 0, 0 }, output);
 	}
 
 	@Test
 	public void test_push23_01() {
-		byte[] output = callWithReturn(new int[] { PUSH23, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		byte[] output = callWithReturn(9, new int[] { PUSH23, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, PUSH1, 0x00, RETURN });
 		assertArrayEquals(new byte[] { 0, 0 }, output);
 	}
 
 	@Test
 	public void test_push24_01() {
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(9,
 				new int[] { PUSH24, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 						0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, PUSH1, 0x00, RETURN });
 		assertArrayEquals(new byte[] { 0, 0 }, output);
@@ -1657,7 +1660,7 @@ public class Tests {
 
 	@Test
 	public void test_push25_01() {
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(9,
 				new int[] { PUSH25, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 						0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, PUSH1, 0x00, RETURN });
 		assertArrayEquals(new byte[] { 0, 0 }, output);
@@ -1665,7 +1668,7 @@ public class Tests {
 
 	@Test
 	public void test_push26_01() {
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(9,
 				new int[] { PUSH26, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 						0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, PUSH1, 0x00, RETURN });
 		assertArrayEquals(new byte[] { 0, 0 }, output);
@@ -1673,7 +1676,7 @@ public class Tests {
 
 	@Test
 	public void test_push27_01() {
-		byte[] output = callWithReturn(new int[] { PUSH27, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		byte[] output = callWithReturn(9, new int[] { PUSH27, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02,
 				PUSH1, 0x00, RETURN });
 		assertArrayEquals(new byte[] { 0, 0 }, output);
@@ -1681,7 +1684,7 @@ public class Tests {
 
 	@Test
 	public void test_push28_01() {
-		byte[] output = callWithReturn(new int[] { PUSH28, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		byte[] output = callWithReturn(9, new int[] { PUSH28, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 				0x02, PUSH1, 0x00, RETURN });
 		assertArrayEquals(new byte[] { 0, 0 }, output);
@@ -1689,7 +1692,7 @@ public class Tests {
 
 	@Test
 	public void test_push29_01() {
-		byte[] output = callWithReturn(new int[] { PUSH29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		byte[] output = callWithReturn(9, new int[] { PUSH29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 				0x00, 0x02, PUSH1, 0x00, RETURN });
 		assertArrayEquals(new byte[] { 0, 0 }, output);
@@ -1697,7 +1700,7 @@ public class Tests {
 
 	@Test
 	public void test_push30_01() {
-		byte[] output = callWithReturn(new int[] { PUSH30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		byte[] output = callWithReturn(9, new int[] { PUSH30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 				0x00, 0x00, 0x02, PUSH1, 0x00, RETURN });
 		assertArrayEquals(new byte[] { 0, 0 }, output);
@@ -1705,7 +1708,7 @@ public class Tests {
 
 	@Test
 	public void test_push31_01() {
-		byte[] output = callWithReturn(new int[] { PUSH31, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		byte[] output = callWithReturn(9, new int[] { PUSH31, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 				0x00, 0x00, 0x00, 0x02, PUSH1, 0x00, RETURN });
 		assertArrayEquals(new byte[] { 0, 0 }, output);
@@ -1713,7 +1716,7 @@ public class Tests {
 
 	@Test
 	public void test_push32_01() {
-		byte[] output = callWithReturn(new int[] { PUSH32, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		byte[] output = callWithReturn(9, new int[] { PUSH32, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 				0x00, 0x00, 0x00, 0x00, 0x02, PUSH1, 0x00, RETURN });
 		assertArrayEquals(new byte[] { 0, 0 }, output);
@@ -1723,96 +1726,105 @@ public class Tests {
 	// 80s: Duplicate Operations
 	// ========================================================================
 
-	@Test
-	public void test_dup1_01() {
-		byte[] output = callWithReturn(
-				new int[] { PUSH1, 0x3d, DUP1, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
-		assertArrayEquals(UINT256(0x3d), output);
-	}
+    @Test
+    public void test_dup1_01() {
+        byte[] output = callWithReturn(21,
+                new int[] { PUSH1, 0x3d, DUP1, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
+        assertArrayEquals(UINT256(0x3d), output);
+    }
 
-	@Test
-	public void test_dup2_01() {
-		byte[] output = callWithReturn(
-				new int[] { PUSH1, 0x3d, PUSH1, 0x0, DUP2, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
-		assertArrayEquals(UINT256(0x3d), output);
-	}
+    @Test
+    public void test_dup2_01() {
+        byte[] output = callWithReturn(24,
+                new int[] { PUSH1, 0x3d, PUSH1, 0x0, DUP2, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
+        assertArrayEquals(UINT256(0x3d), output);
+    }
 
-	@Test
-	public void test_dup3_01() {
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x3d, PUSH1, 0x0, PUSH1, 0x0, DUP3, PUSH1, 0x00, MSTORE,
-				PUSH1, 0x20, PUSH1, 0x00, RETURN });
-		assertArrayEquals(UINT256(0x3d), output);
-	}
+    @Test
+    public void test_dup3_01() {
+        byte[] output = callWithReturn(27,
+                new int[] { PUSH1, 0x3d, PUSH1, 0x0, PUSH1, 0x0, DUP3, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00,
+                        RETURN });
+        assertArrayEquals(UINT256(0x3d), output);
+    }
 
-	@Test
-	public void test_dup4_01() {
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x3d, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, DUP4, PUSH1, 0x00,
-				MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
-		assertArrayEquals(UINT256(0x3d), output);
-	}
+    @Test
+    public void test_dup4_01() {
+        byte[] output = callWithReturn(30,
+                new int[] { PUSH1, 0x3d, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, DUP4, PUSH1, 0x00, MSTORE, PUSH1, 0x20,
+                        PUSH1, 0x00, RETURN });
+        assertArrayEquals(UINT256(0x3d), output);
+    }
 
-	@Test
-	public void test_dup5_01() {
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x3d, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, DUP5,
-				PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
-		assertArrayEquals(UINT256(0x3d), output);
-	}
+    @Test
+    public void test_dup5_01() {
+        byte[] output = callWithReturn(33,
+                new int[] { PUSH1, 0x3d, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, DUP5, PUSH1, 0x00, MSTORE,
+                        PUSH1, 0x20, PUSH1, 0x00, RETURN });
+        assertArrayEquals(UINT256(0x3d), output);
+    }
 
-	@Test
-	public void test_dup6_01() {
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x3d, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1,
-				0x0, DUP6, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
-		assertArrayEquals(UINT256(0x3d), output);
-	}
+    @Test
+    public void test_dup6_01() {
+        byte[] output = callWithReturn(36,
+                new int[] { PUSH1, 0x3d, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, DUP6, PUSH1, 0x00,
+                        MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
+        assertArrayEquals(UINT256(0x3d), output);
+    }
 
-	@Test
-	public void test_dup7_01() {
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x3d, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1,
-				0x0, PUSH1, 0x0, DUP7, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
-		assertArrayEquals(UINT256(0x3d), output);
-	}
+    @Test
+    public void test_dup7_01() {
+        byte[] output = callWithReturn(39,
+                new int[] { PUSH1, 0x3d, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, DUP7,
+                        PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
+        assertArrayEquals(UINT256(0x3d), output);
+    }
 
-	@Test
-	public void test_dup8_01() {
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x3d, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1,
-				0x0, PUSH1, 0x0, PUSH1, 0x0, DUP8, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
-		assertArrayEquals(UINT256(0x3d), output);
-	}
+    @Test
+    public void test_dup8_01() {
+        byte[] output = callWithReturn(42,
+                new int[] { PUSH1, 0x3d, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1,
+                        0x0, DUP8, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
+        assertArrayEquals(UINT256(0x3d), output);
+    }
 
-	@Test
-	public void test_dup9_01() {
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x3d, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1,
-				0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, DUP9, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
-		assertArrayEquals(UINT256(0x3d), output);
-	}
+    @Test
+    public void test_dup9_01() {
+        byte[] output = callWithReturn(45,
+                new int[] { PUSH1, 0x3d, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1,
+                        0x0, PUSH1, 0x0, DUP9, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
+        assertArrayEquals(UINT256(0x3d), output);
+    }
 
-	@Test
-	public void test_dup10_01() {
-		byte[] output = callWithReturn(
-				new int[] { PUSH1, 0x3d, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1,
-						0x0, PUSH1, 0x0, PUSH1, 0x0, DUP10, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
-		assertArrayEquals(UINT256(0x3d), output);
-	}
+    @Test
+    public void test_dup10_01() {
+        byte[] output = callWithReturn(48,
+                new int[] { PUSH1, 0x3d, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1,
+                        0x0, PUSH1, 0x0, PUSH1, 0x0, DUP10, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
+        assertArrayEquals(UINT256(0x3d), output);
+    }
 
-	@Test
-	public void test_dup11_01() {
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x3d, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1,
-				0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, DUP11, PUSH1, 0x00, MSTORE, PUSH1,
-				0x20, PUSH1, 0x00, RETURN });
-		assertArrayEquals(UINT256(0x3d), output);
-	}
+    @Test
+    public void test_dup11_01() {
+        byte[] output = callWithReturn(51,
+                new int[] { PUSH1, 0x3d, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1,
+                        0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, DUP11, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00,
+                        RETURN });
+        assertArrayEquals(UINT256(0x3d), output);
+    }
 
-	@Test
-	public void test_dup12_01() {
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x3d, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1,
-				0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, DUP12, PUSH1, 0x00, MSTORE,
-				PUSH1, 0x20, PUSH1, 0x00, RETURN });
-		assertArrayEquals(UINT256(0x3d), output);
-	}
+    @Test
+    public void test_dup12_01() {
+        byte[] output = callWithReturn(54,
+                new int[] { PUSH1, 0x3d, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1,
+                        0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, DUP12, PUSH1, 0x00, MSTORE, PUSH1, 0x20,
+                        PUSH1, 0x00, RETURN });
+        assertArrayEquals(UINT256(0x3d), output);
+    }
 
 	@Test
 	public void test_dup13_01() {
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x3d, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1,
+		byte[] output = callWithReturn(57,new int[] { PUSH1, 0x3d, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1,
 				0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, DUP13, PUSH1,
 				0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x3d), output);
@@ -1820,7 +1832,7 @@ public class Tests {
 
 	@Test
 	public void test_dup14_01() {
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x3d, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1,
+		byte[] output = callWithReturn(60,new int[] { PUSH1, 0x3d, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1,
 				0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0,
 				DUP14, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x3d), output);
@@ -1828,7 +1840,7 @@ public class Tests {
 
 	@Test
 	public void test_dup15_01() {
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x3d, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1,
+		byte[] output = callWithReturn(63,new int[] { PUSH1, 0x3d, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1,
 				0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0,
 				PUSH1, 0x0, DUP15, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x3d), output);
@@ -1836,7 +1848,7 @@ public class Tests {
 
 	@Test
 	public void test_dup16_01() {
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x3d, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1,
+		byte[] output = callWithReturn(66,new int[] { PUSH1, 0x3d, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1,
 				0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0,
 				PUSH1, 0x0, PUSH1, 0x0, DUP16, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x3d), output);
@@ -1848,56 +1860,56 @@ public class Tests {
 
 	@Test
 	public void test_swap1_01() {
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(24,
 				new int[] { PUSH1, 0x1, PUSH1, 0x2, SWAP1, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x1), output);
 	}
 
 	@Test
 	public void test_swap2_01() {
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x1, PUSH1, 0x0, PUSH1, 0x2, SWAP2, PUSH1, 0x00, MSTORE,
-				PUSH1, 0x20, PUSH1, 0x00, RETURN });
+		byte[] output = callWithReturn(27,
+		        new int[] { PUSH1, 0x1, PUSH1, 0x0, PUSH1, 0x2, SWAP2, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x1), output);
 	}
 
 	@Test
 	public void test_swap3_01() {
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x1, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x2, SWAP3, PUSH1, 0x00,
-				MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
+		byte[] output = callWithReturn(30,
+		        new int[] { PUSH1, 0x1, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x2, SWAP3, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x1), output);
 	}
 
 	@Test
 	public void test_swap4_01() {
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x1, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x2, SWAP4,
-				PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
+		byte[] output = callWithReturn(33,
+		        new int[] { PUSH1, 0x1, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x2, SWAP4, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x1), output);
 	}
 
 	@Test
 	public void test_swap5_01() {
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x1, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1,
-				0x2, SWAP5, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
+		byte[] output = callWithReturn(36,
+		        new int[] { PUSH1, 0x1, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x2, SWAP5, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x1), output);
 	}
 
 	@Test
 	public void test_swap6_01() {
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x1, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1,
-				0x0, PUSH1, 0x2, SWAP6, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
+		byte[] output = callWithReturn(39,
+		        new int[] { PUSH1, 0x1, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x2, SWAP6, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x1), output);
 	}
 
 	@Test
 	public void test_swap7_01() {
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x1, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1,
-				0x0, PUSH1, 0x0, PUSH1, 0x2, SWAP7, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
+		byte[] output = callWithReturn(42,
+		        new int[] { PUSH1, 0x1, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x2, SWAP7, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x1), output);
 	}
 
 	@Test
 	public void test_swap8_01() {
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(45,
 				new int[] { PUSH1, 0x1, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1,
 						0x0, PUSH1, 0x2, SWAP8, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x1), output);
@@ -1905,7 +1917,7 @@ public class Tests {
 
 	@Test
 	public void test_swap9_01() {
-		byte[] output = callWithReturn(
+		byte[] output = callWithReturn(48,
 				new int[] { PUSH1, 0x1, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1,
 						0x0, PUSH1, 0x0, PUSH1, 0x2, SWAP9, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x1), output);
@@ -1913,7 +1925,7 @@ public class Tests {
 
 	@Test
 	public void test_swap10_01() {
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x1, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1,
+		byte[] output = callWithReturn(51, new int[] { PUSH1, 0x1, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1,
 				0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x2, SWAP10, PUSH1, 0x00, MSTORE, PUSH1,
 				0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x1), output);
@@ -1921,7 +1933,7 @@ public class Tests {
 
 	@Test
 	public void test_swap11_01() {
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x1, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1,
+		byte[] output = callWithReturn(54, new int[] { PUSH1, 0x1, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1,
 				0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x2, SWAP11, PUSH1, 0x00,
 				MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x1), output);
@@ -1929,7 +1941,7 @@ public class Tests {
 
 	@Test
 	public void test_swap12_01() {
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x1, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1,
+		byte[] output = callWithReturn(57, new int[] { PUSH1, 0x1, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1,
 				0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x2, SWAP12, PUSH1,
 				0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x1), output);
@@ -1937,7 +1949,7 @@ public class Tests {
 
 	@Test
 	public void test_swap13_01() {
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x1, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1,
+		byte[] output = callWithReturn(60, new int[] { PUSH1, 0x1, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1,
 				0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x2,
 				SWAP13, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x1), output);
@@ -1945,7 +1957,7 @@ public class Tests {
 
 	@Test
 	public void test_swap14_01() {
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x1, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1,
+		byte[] output = callWithReturn(63, new int[] { PUSH1, 0x1, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1,
 				0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0,
 				PUSH1, 0x2, SWAP14, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x1), output);
@@ -1953,7 +1965,7 @@ public class Tests {
 
 	@Test
 	public void test_swap15_01() {
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x1, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1,
+		byte[] output = callWithReturn(66, new int[] { PUSH1, 0x1, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1,
 				0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0,
 				PUSH1, 0x0, PUSH1, 0x2, SWAP15, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x1), output);
@@ -1961,7 +1973,7 @@ public class Tests {
 
 	@Test
 	public void test_swap16_01() {
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x1, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1,
+		byte[] output = callWithReturn(69,new int[] { PUSH1, 0x1, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1,
 				0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x0,
 				PUSH1, 0x0, PUSH1, 0x0, PUSH1, 0x2, SWAP16, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN });
 		assertArrayEquals(UINT256(0x1), output);
@@ -1974,7 +1986,8 @@ public class Tests {
 	@Test
 	public void test_log_01() {
 		// Log 1 byte of data.
-		Pair<BigInteger[], byte[]>[] log = call(new int[] { PUSH1, 0x1, PUSH1, 0x0, LOG0 }).getLog();
+	    DafnyEvm tx = new DafnyEvm();
+		Pair<BigInteger[], byte[]>[] log = call(392, tx, new int[] { PUSH1, 0x1, PUSH1, 0x0, LOG0 }).getLog();
 		assertEquals(1, log.length); // excactly one entry
 		assertEquals(0, log[0].getLeft().length); // no topics
 		assertArrayEquals(new byte[] { 0 }, log[0].getRight());
@@ -1983,7 +1996,8 @@ public class Tests {
 	@Test
 	public void test_log_02() {
 		// Log 32 bytes of data matching 0x123.
-		Pair<BigInteger[], byte[]>[] log = call(
+	    DafnyEvm tx = new DafnyEvm();
+		Pair<BigInteger[], byte[]>[] log = call(649, tx,
 				new int[] { PUSH2, 0x1, 0x23, PUSH1, 0x0, MSTORE, PUSH1, 0x20, PUSH1, 0x0, LOG0 }).getLog();
 		assertEquals(1, log.length); // excactly one entry
 		assertEquals(0, log[0].getLeft().length); // no topics
@@ -1993,7 +2007,8 @@ public class Tests {
 	@Test
 	public void test_log_03() {
 		// Log 32 bytes of data matching 0x123 from a different position.
-		Pair<BigInteger[], byte[]>[] log = call(
+	    DafnyEvm tx = new DafnyEvm();
+		Pair<BigInteger[], byte[]>[] log = call(652, tx,
 				new int[] { PUSH2, 0x1, 0x23, PUSH1, 0x10, MSTORE, PUSH1, 0x20, PUSH1, 0x11, LOG0 }).getLog();
 		assertEquals(1, log.length); // excactly one entry
 		assertEquals(0, log[0].getLeft().length); // no topics
@@ -2003,7 +2018,9 @@ public class Tests {
 	@Test
 	public void test_log_04() {
 		// Log no data, but 1 topic (0xa0).
-		Pair<BigInteger[], byte[]>[] log = call(new int[] { PUSH1, 0xa0, PUSH1, 0x0, PUSH1, 0x0, LOG1 }).getLog();
+	    DafnyEvm tx = new DafnyEvm();
+		Pair<BigInteger[], byte[]>[] log = call(759, tx,
+		        new int[] { PUSH1, 0xa0, PUSH1, 0x0, PUSH1, 0x0, LOG1 }).getLog();
 		assertEquals(1, log.length); // excactly one entry
 		assertEquals(1, log[0].getLeft().length); // one topic
 		assertEquals(0, log[0].getRight().length); // no data
@@ -2013,7 +2030,9 @@ public class Tests {
 	@Test
 	public void test_log_05() {
 		// Log no data, but 2 topics (0xa, 0xb).
-		Pair<BigInteger[], byte[]>[] log = call(new int[] { PUSH1, 0xa, PUSH1, 0xb, PUSH1, 0x0, PUSH1, 0x0, LOG2 })
+	    DafnyEvm tx = new DafnyEvm();
+		Pair<BigInteger[], byte[]>[] log = call(1137, tx,
+		        new int[] { PUSH1, 0xa, PUSH1, 0xb, PUSH1, 0x0, PUSH1, 0x0, LOG2 })
 				.getLog();
 		assertEquals(1, log.length); // excactly one entry
 		assertEquals(2, log[0].getLeft().length); // two topics
@@ -2025,7 +2044,8 @@ public class Tests {
 	@Test
 	public void test_log_06() {
 		// Log no data, but 3 topics (0xa, 0xb, 0xc).
-		Pair<BigInteger[], byte[]>[] log = call(
+	    DafnyEvm tx = new DafnyEvm();
+		Pair<BigInteger[], byte[]>[] log = call(1515, tx,
 				new int[] { PUSH1, 0xa, PUSH1, 0xb, PUSH1, 0xc, PUSH1, 0x0, PUSH1, 0x0, LOG3 }).getLog();
 		assertEquals(1, log.length); // excactly one entry
 		assertEquals(3, log[0].getLeft().length); // three topics
@@ -2038,7 +2058,8 @@ public class Tests {
 	@Test
 	public void test_log_07() {
 		// Log no data, but 4 topics (0xa, 0xb, 0xc, 0xd).
-		Pair<BigInteger[], byte[]>[] log = call(
+	    DafnyEvm tx = new DafnyEvm();
+		Pair<BigInteger[], byte[]>[] log = call(1893, tx,
 				new int[] { PUSH1, 0xa, PUSH1, 0xb, PUSH1, 0xc, PUSH1, 0xd, PUSH1, 0x0, PUSH1, 0x0, LOG4 }).getLog();
 		assertEquals(1, log.length); // excactly one entry
 		assertEquals(4, log[0].getLeft().length); // three topics
@@ -2054,7 +2075,7 @@ public class Tests {
 		// Log 32 bytes of data matching 0x123 from within contract call.
 		DafnyEvm tx = new DafnyEvm().create(CONTRACT_1,
 				toBytes(PUSH2, 0x1, 0x23, PUSH1, 0x0, MSTORE, PUSH1, 0x20, PUSH1, 0x0, LOG0));
-		Pair<BigInteger[], byte[]>[] log = call(tx,
+		Pair<BigInteger[], byte[]>[] log = call(3273, tx,
 				new int[] { PUSH1, 0x20, PUSH1, 0x00, DUP1, DUP1, DUP1, PUSH2, 0xc, 0xcc, PUSH2, 0xff, 0xff, CALL })
 						.getLog();
 		//
@@ -2069,7 +2090,7 @@ public class Tests {
 		// fails (hence no log produced).
 		DafnyEvm tx = new DafnyEvm().create(CONTRACT_1,
 				toBytes(PUSH2, 0x1, 0x23, PUSH1, 0x0, MSTORE, PUSH1, 0x20, PUSH1, 0x0, LOG0, INVALID));
-		Pair<BigInteger[], byte[]>[] log = call(tx,
+		Pair<BigInteger[], byte[]>[] log = call(68159, tx,
 				new int[] { PUSH1, 0x20, PUSH1, 0x00, DUP1, DUP1, DUP1, PUSH2, 0xc, 0xcc, PUSH2, 0xff, 0xff, CALL })
 						.getLog();
 		//
@@ -2082,7 +2103,7 @@ public class Tests {
 		// another 32 bytes matching 0x456 afterwards.
 		DafnyEvm tx = new DafnyEvm().create(CONTRACT_1,
 				toBytes(PUSH2, 0x1, 0x23, PUSH1, 0x0, MSTORE, PUSH1, 0x20, PUSH1, 0x0, LOG0));
-		Pair<BigInteger[], byte[]>[] log = call(tx, new int[] {
+		Pair<BigInteger[], byte[]>[] log = call(3919, tx, new int[] {
 				// Make the contract call to 0xccc
 				PUSH1, 0x20, PUSH1, 0x00, DUP1, DUP1, DUP1, PUSH2, 0xc, 0xcc, PUSH2, 0xff, 0xff, CALL,
 				// Log 32 bytes matching 0x456
@@ -2103,7 +2124,7 @@ public class Tests {
 		// from within contract call.
 		DafnyEvm tx = new DafnyEvm().create(CONTRACT_1,
 				toBytes(PUSH2, 0x4, 0x56, PUSH1, 0x0, MSTORE, PUSH1, 0x20, PUSH1, 0x0, LOG0));
-		Pair<BigInteger[], byte[]>[] log = call(tx, new int[] {
+		Pair<BigInteger[], byte[]>[] log = call(3919, tx, new int[] {
 				// Log 32 bytes matching 0x123
 				PUSH2, 0x1, 0x23, PUSH1, 0x0, MSTORE, PUSH1, 0x20, PUSH1, 0x0, LOG0,
 				// Make the contract call to 0xccc
@@ -2134,7 +2155,7 @@ public class Tests {
 	@Test
 	public void test_create_01() {
 		// Create an empty contract, and return exit code.
-		byte[] output = callWithReturn(new int[] {
+		byte[] output = callWithReturn(32024, new int[] {
 				// Create contact with no code and no endowment.
 				PUSH1, 0x00, DUP1, DUP1, CREATE,
 				// Return exit code.
@@ -2145,9 +2166,10 @@ public class Tests {
 
 	@Test
 	public void test_create_02() {
+	    DafnyEvm tx = new DafnyEvm().gas(49208);
 		// Create contract with initialisation code that raises an exception, and return
 		// exit code (which should be zero).
-		byte[] output = callWithReturn(new int[] {
+		byte[] output = callWithReturn(48952, tx, new int[] {
 				// Construct initialisation code
 				PUSH1, 0xfe, PUSH1, 0x00, MSTORE8,
 				// Create contact with 1 byte of code.
@@ -2163,7 +2185,7 @@ public class Tests {
 		// Absolutely minimal contract call which does nothing, and the caller then
 		// returns the (successful) exit code.
 		DafnyEvm tx = new DafnyEvm().create(CONTRACT_1, toBytes(STOP));
-		byte[] output = callWithReturn(tx, new int[] {
+		byte[] output = callWithReturn(2636, tx, new int[] {
 				// Make contract call to 0xccc with gas 0xffff
 				PUSH1, 0x0, DUP1, DUP1, DUP1, DUP1, PUSH2, 0xc, 0xcc, PUSH2, 0xff, 0xff, CALL,
 				// Write exit code to memory and return.
@@ -2178,7 +2200,7 @@ public class Tests {
 		// then returned by the caller.
 		DafnyEvm tx = new DafnyEvm().create(CONTRACT_1, toBytes(INVALID));
 		//
-		byte[] output = callWithReturn(tx, new int[] {
+		byte[] output = callWithReturn(68171, tx, new int[] {
 				// Make contract call to 0xccc with gas 0xffff
 				PUSH1, 0x0, DUP1, DUP1, DUP1, DUP1, PUSH2, 0xc, 0xcc, PUSH2, 0xff, 0xff, CALL,
 				// Write exit code to memory and return.
@@ -2192,7 +2214,7 @@ public class Tests {
 		// Contract call which reverts, and the subsequence exit code is then returned
 		// by the caller.
 		DafnyEvm tx = new DafnyEvm().create(CONTRACT_1, toBytes(PUSH1, 0x00, DUP1, REVERT));
-		byte[] output = callWithReturn(tx, new int[] {
+		byte[] output = callWithReturn(2642, tx, new int[] {
 				// Make contract call to 0xccc with gas 0xffff
 				PUSH1, 0x0, DUP1, DUP1, DUP1, DUP1, PUSH2, 0xc, 0xcc, PUSH2, 0xff, 0xff, CALL,
 				// Write exit code to memory and return.
@@ -2206,7 +2228,7 @@ public class Tests {
 		// Contract call which returns "0x123", which the caller then itself returns.
 		DafnyEvm tx = new DafnyEvm().create(CONTRACT_1,
 				toBytes(PUSH2, 0x1, 0x23, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN));
-		byte[] output = callWithReturn(tx, new int[] {
+		byte[] output = callWithReturn(2648, tx, new int[] {
 				// Make contract call to 0xccc with gas 0xffff, providing 32bytes for the return
 				// data at address 0.
 				PUSH1, 0x20, PUSH1, 0x00, DUP1, DUP1, DUP1, PUSH2, 0xc, 0xcc, PUSH2, 0xff, 0xff, CALL,
@@ -2223,7 +2245,7 @@ public class Tests {
 		DafnyEvm tx = new DafnyEvm().create(CONTRACT_1,
 				toBytes(PUSH1, 0x00, CALLDATALOAD, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN));
 
-		byte[] output = callWithReturn(tx, new int[] {
+		byte[] output = callWithReturn(2663, tx, new int[] {
 				// Write 0x123 to address 0x20
 				PUSH2, 0x1, 0x23, PUSH1, 0x20, MSTORE,
 				// Make contract call to 0xccc with gas 0xffff, providing 32bytes for the return
@@ -2243,7 +2265,7 @@ public class Tests {
 		DafnyEvm tx = new DafnyEvm().create(CONTRACT_1,
 				toBytes(PUSH1, 0x00, CALLDATALOAD, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN));
 
-		byte[] output = callWithReturn(tx, new int[] {
+		byte[] output = callWithReturn(2663, tx, new int[] {
 				// Write 0x123 to address 0x20
 				PUSH2, 0x1, 0x23, PUSH1, 0x20, MSTORE,
 				// Make contract call to 0xccc with gas 0xffff, providing 32bytes for the return
@@ -2263,7 +2285,7 @@ public class Tests {
 		DafnyEvm tx = new DafnyEvm().create(CONTRACT_1,
 				toBytes(PUSH1, 0x00, CALLDATALOAD, PUSH1, 0x00, MSTORE, PUSH1, 0x1F, PUSH1, 0x00, RETURN));
 
-		byte[] output = callWithReturn(tx, new int[] {
+		byte[] output = callWithReturn(2663, tx, new int[] {
 				// Write 0x123 to address 0x20
 				PUSH2, 0x1, 0x23, PUSH1, 0x20, MSTORE,
 				// Make contract call to 0xccc with gas 0xffff, providing 32bytes for the return
@@ -2283,7 +2305,7 @@ public class Tests {
 		DafnyEvm tx = new DafnyEvm().create(CONTRACT_1,
 				toBytes(PUSH1, 0x00, CALLDATALOAD, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN));
 
-		byte[] output = callWithReturn(tx, new int[] {
+		byte[] output = callWithReturn(2663, tx, new int[] {
 				// Write 0x123 to address 0x20
 				PUSH2, 0x1, 0x23, PUSH1, 0x20, MSTORE,
 				// Make contract call to 0xccc with gas 0xffff, providing 32bytes for the return
@@ -2302,7 +2324,7 @@ public class Tests {
 		// address (i.e. since we're using a CALLCODE instruction).
 		DafnyEvm tx = new DafnyEvm().create(CONTRACT_1,
 				toBytes(ADDRESS, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN));
-		byte[] output = callWithReturn(tx, new int[] {
+		byte[] output = callWithReturn(2647, tx, new int[] {
 				// Make contract call to 0xccc with gas 0xffff, providing 32bytes for the return
 				// data at address 0.
 				PUSH1, 0x20, PUSH1, 0x00, DUP1, DUP1, DUP1, PUSH2, 0xc, 0xcc, PUSH2, 0xff, 0xff, CALL,
@@ -2317,7 +2339,7 @@ public class Tests {
 		// Contract call which returns storage value, and then increments that value.  Thus, subsequent calls get increasing values.
 		DafnyEvm tx = new DafnyEvm().create(CONTRACT_1,
 				toBytes(PUSH1, 0x00, SLOAD, DUP1, PUSH1, 0x00, MSTORE, PUSH1,0x1, ADD, PUSH1, 0x00, SSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN));
-		byte[] output = callWithReturn(tx, new int[] {
+		byte[] output = callWithReturn(25111, tx, new int[] {
 				// Call contract
 				PUSH1, 0x20, PUSH1, 0x00, DUP1, DUP1, DUP1, PUSH2, 0xc, 0xcc, PUSH2, 0xff, 0xff, CALL,
 				// Call contract (again).
@@ -2340,8 +2362,10 @@ public class Tests {
 
 	@Test
 	public void test_recursive_call_02() {
+	 // Recursive contract call (with lots of gas)
+        DafnyEvm tx = new DafnyEvm().gas(Long.MAX_VALUE);
 		// Recursive contract call
-		byte[] output = callWithReturn(new int[] {
+		byte[] output = callWithReturn(2684, tx,new int[] {
 				// Branch to STOP if calldata == 0xF.
 				PUSH1, 0x00, CALLDATALOAD, DUP1, PUSH1, 0xF, EQ, PUSH1, 0x21, JUMPI,
 				// Add one to value for next call
@@ -2358,7 +2382,7 @@ public class Tests {
 		// Recursive contract call (with lots of gas)
 		DafnyEvm tx = new DafnyEvm().gas(Long.MAX_VALUE);
 		//
-		byte[] output = callWithReturn(tx,new int[] {
+		byte[] output = callWithReturn(180077, tx,new int[] {
 				// Branch to STOP if calldata == 0x3ff.
 				PUSH1, 0x00, CALLDATALOAD, DUP1, PUSH2, 0x3, 0xff, EQ, PUSH1, 0x20, JUMPI,
 				// Add one to value for next call
@@ -2375,7 +2399,7 @@ public class Tests {
 		// Absolutely minimal contract call which does nothing, and the caller then
 		// returns the (successful) exit code.
 		DafnyEvm tx = new DafnyEvm().create(CONTRACT_1, toBytes(STOP));
-		byte[] output = callWithReturn(tx, new int[] {
+		byte[] output = callWithReturn(2636, tx, new int[] {
 				// Make contract call to 0xccc with gas 0xffff
 				PUSH1, 0x0, DUP1, DUP1, DUP1, DUP1, PUSH2, 0xc, 0xcc, PUSH2, 0xff, 0xff, CALLCODE,
 				// Write exit code to memory and return.
@@ -2390,7 +2414,7 @@ public class Tests {
 		// then returned by the caller.
 		DafnyEvm tx = new DafnyEvm().create(CONTRACT_1, toBytes(INVALID));
 		//
-		byte[] output = callWithReturn(tx, new int[] {
+		byte[] output = callWithReturn(68171, tx, new int[] {
 				// Make contract call to 0xccc with gas 0xffff
 				PUSH1, 0x0, DUP1, DUP1, DUP1, DUP1, PUSH2, 0xc, 0xcc, PUSH2, 0xff, 0xff, CALLCODE,
 				// Write exit code to memory and return.
@@ -2404,7 +2428,7 @@ public class Tests {
 		// Contract call which reverts, and the subsequence exit code is then returned
 		// by the caller.
 		DafnyEvm tx = new DafnyEvm().create(CONTRACT_1, toBytes(PUSH1, 0x00, DUP1, REVERT));
-		byte[] output = callWithReturn(tx, new int[] {
+		byte[] output = callWithReturn(2642, tx, new int[] {
 				// Make contract call to 0xccc with gas 0xffff
 				PUSH1, 0x0, DUP1, DUP1, DUP1, DUP1, PUSH2, 0xc, 0xcc, PUSH2, 0xff, 0xff, CALLCODE,
 				// Write exit code to memory and return.
@@ -2418,7 +2442,7 @@ public class Tests {
 		// Contract call which returns "0x123", which the caller then itself returns.
 		DafnyEvm tx = new DafnyEvm().create(CONTRACT_1,
 				toBytes(PUSH2, 0x1, 0x23, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN));
-		byte[] output = callWithReturn(tx, new int[] {
+		byte[] output = callWithReturn(2648, tx, new int[] {
 				// Make contract call to 0xccc with gas 0xffff, providing 32bytes for the return
 				// data at address 0.
 				PUSH1, 0x20, PUSH1, 0x00, DUP1, DUP1, DUP1, PUSH2, 0xc, 0xcc, PUSH2, 0xff, 0xff, CALLCODE,
@@ -2435,7 +2459,7 @@ public class Tests {
 		DafnyEvm tx = new DafnyEvm().create(CONTRACT_1,
 				toBytes(PUSH1, 0x00, CALLDATALOAD, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN));
 
-		byte[] output = callWithReturn(tx, new int[] {
+		byte[] output = callWithReturn(2663, tx, new int[] {
 				// Write 0x123 to address 0x20
 				PUSH2, 0x1, 0x23, PUSH1, 0x20, MSTORE,
 				// Make contract call to 0xccc with gas 0xffff, providing 32bytes for the return
@@ -2455,7 +2479,7 @@ public class Tests {
 		DafnyEvm tx = new DafnyEvm().create(CONTRACT_1,
 				toBytes(PUSH1, 0x00, CALLDATALOAD, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN));
 
-		byte[] output = callWithReturn(tx, new int[] {
+		byte[] output = callWithReturn(2663, tx, new int[] {
 				// Write 0x123 to address 0x20
 				PUSH2, 0x1, 0x23, PUSH1, 0x20, MSTORE,
 				// Make contract call to 0xccc with gas 0xffff, providing 32bytes for the return
@@ -2475,7 +2499,7 @@ public class Tests {
 		DafnyEvm tx = new DafnyEvm().create(CONTRACT_1,
 				toBytes(PUSH1, 0x00, CALLDATALOAD, PUSH1, 0x00, MSTORE, PUSH1, 0x1F, PUSH1, 0x00, RETURN));
 
-		byte[] output = callWithReturn(tx, new int[] {
+		byte[] output = callWithReturn(2663, tx, new int[] {
 				// Write 0x123 to address 0x20
 				PUSH2, 0x1, 0x23, PUSH1, 0x20, MSTORE,
 				// Make contract call to 0xccc with gas 0xffff, providing 32bytes for the return
@@ -2495,7 +2519,7 @@ public class Tests {
 		DafnyEvm tx = new DafnyEvm().create(CONTRACT_1,
 				toBytes(PUSH1, 0x00, CALLDATALOAD, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN));
 
-		byte[] output = callWithReturn(tx, new int[] {
+		byte[] output = callWithReturn(2663, tx, new int[] {
 				// Write 0x123 to address 0x20
 				PUSH2, 0x1, 0x23, PUSH1, 0x20, MSTORE,
 				// Make contract call to 0xccc with gas 0xffff, providing 32bytes for the return
@@ -2514,7 +2538,7 @@ public class Tests {
 		// address (i.e. since we're using a CALLCODE instruction).
 		DafnyEvm tx = new DafnyEvm().create(CONTRACT_1,
 				toBytes(ADDRESS, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN));
-		byte[] output = callWithReturn(tx, new int[] {
+		byte[] output = callWithReturn(2647, tx, new int[] {
 				// Make contract call to 0xccc with gas 0xffff, providing 32bytes for the return
 				// data at address 0.
 				PUSH1, 0x20, PUSH1, 0x00, DUP1, DUP1, DUP1, PUSH2, 0xc, 0xcc, PUSH2, 0xff, 0xff, CALLCODE,
@@ -2530,7 +2554,7 @@ public class Tests {
 		// returns.
 		DafnyEvm tx = new DafnyEvm().create(CONTRACT_1,
 				toBytes(CALLER, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN));
-		byte[] output = callWithReturn(tx, new int[] {
+		byte[] output = callWithReturn(2644, tx, new int[] {
 				// Make delegatecall to 0xccc with gas 0xffff, providing 32bytes for the return
 				// data at address 0.
 				PUSH1, 0x20, PUSH1, 0x00, DUP1, DUP1, PUSH2, 0xc, 0xcc, PUSH2, 0xff, 0xff, DELEGATECALL,
@@ -2546,7 +2570,7 @@ public class Tests {
 		// returns.
 		DafnyEvm tx = new DafnyEvm().create(CONTRACT_1,
 				toBytes(ORIGIN, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN));
-		byte[] output = callWithReturn(tx, new int[] {
+		byte[] output = callWithReturn(2644, tx, new int[] {
 				// Make delegatecall to 0xccc with gas 0xffff, providing 32bytes for the return
 				// data at address 0.
 				PUSH1, 0x20, PUSH1, 0x00, DUP1, DUP1, PUSH2, 0xc, 0xcc, PUSH2, 0xff, 0xff, DELEGATECALL,
@@ -2562,7 +2586,7 @@ public class Tests {
 		// returns.
 		DafnyEvm tx = new DafnyEvm().create(CONTRACT_1,
 				toBytes(ADDRESS, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN));
-		byte[] output = callWithReturn(tx, new int[] {
+		byte[] output = callWithReturn(2644, tx, new int[] {
 				// Make delegatecall to 0xccc with gas 0xffff, providing 32bytes for the return
 				// data at address 0.
 				PUSH1, 0x20, PUSH1, 0x00, DUP1, DUP1, PUSH2, 0xc, 0xcc, PUSH2, 0xff, 0xff, DELEGATECALL,
@@ -2598,22 +2622,22 @@ public class Tests {
 	@Test
 	public void test_invalid_02() {
 		// Run off end of code sequence.
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x01 });
+        byte[] output = callWithReturn(3, new int[] { PUSH1, 0x01 });
 		assertArrayEquals(new byte[0], output);
 	}
 
 	@Test
 	public void test_selfdestruct_01() {
-		byte[] output = callWithReturn(new int[] { PUSH1, 0x00, SELFDESTRUCT });
+		byte[] output = callWithReturn(7603, new int[] { PUSH1, 0x00, SELFDESTRUCT });
 		assertArrayEquals(new byte[0], output);
 	}
 
 	@Test
-	public void test_selfdstruct_02() {
+	public void test_selfdestruct_02() {
 		// Absolutely minimal contract call which does nothing, and the caller then
 		// returns the (successful) exit code.
 		DafnyEvm tx = new DafnyEvm().create(CONTRACT_1, toBytes(PUSH1, 0x00, SELFDESTRUCT));
-		byte[] output = callWithReturn(tx, new int[] {
+		byte[] output = callWithReturn(10239, tx, new int[] {
 				// Make contract call to 0xccc with gas 0xffff
 				PUSH1, 0x0, DUP1, DUP1, DUP1, DUP1, PUSH2, 0xc, 0xcc, PUSH2, 0xff, 0xff, CALL,
 				// Write exit code to memory and return.
@@ -2630,25 +2654,26 @@ public class Tests {
 	 * Run a given sequence of bytecodes, expecting things to go OK and to produce
 	 * the given output (i.e. return data).
 	 *
-	 * @param code The EVM bytecode sequence to execute.
+	 * @param gas The exact amount of gas required for this transaction.
+	 * @param words The EVM bytecode sequence to execute.
 	 */
-	private byte[] callWithReturn(int[] words) {
-		return call(words).getReturnData();
+	private byte[] callWithReturn(long gas, int[] words) {
+	    return call(gas, new DafnyEvm(), words).getReturnData();
+    }
+
+	private byte[] callWithReturn(long gas, DafnyEvm context, int[] words) {
+		return call(gas, context, words).getReturnData();
 	}
 
-	private byte[] callWithReturn(DafnyEvm context, int[] words) {
-		return call(context, words).getReturnData();
-	}
-
-	private DafnyEvm.State<?> call(int[] words) {
-		return call(new DafnyEvm(), words);
-	}
-
-	private DafnyEvm.State<?> call(DafnyEvm context, int[] words) {
+	private DafnyEvm.State<?> call(long gas, DafnyEvm context, int[] words) {
+	    BigInteger limit = context.gas();
 		byte[] code = toBytes(words);
-		System.out.println(Hex.toHexString(code));
+		// System.out.println(Hex.toHexString(code));
 		// context = context.tracer(new Tracers.Debug());
-		return context.create(DEFAULT_RECEIVER, code).call();
+		DafnyEvm.State<?> st = context.create(DEFAULT_RECEIVER, code).call();
+		BigInteger gasUsed = limit.subtract(st.getGas());
+        assertEquals(BigInteger.valueOf(gas), gasUsed);
+        return st;
 	}
 
 	/**


### PR DESCRIPTION
This updates every test to include a gas check.  That is, a check on exactly how much is used versus what we are expecting.  At this stage, I have essentially just implemented this as a regression test rather than trying to calculate the expected cost of each test (though I did calculate some).