### PR TITLE
Minimise occurence of MEMORY_OVERFLOW #378

### DIFF
--- a/src/dafny/state.dfy
+++ b/src/dafny/state.dfy
@@ -592,8 +592,7 @@ module EvmState {
          * Update the return data associated with this state.
          */
         function method SetReturnData(data: seq<u8>) : State
-        requires !IsFailure()
-        requires |data| <= MAX_U256 {
+        requires !IsFailure() {
             OK(evm.(context:=evm.context.SetReturnData(data)))
         }
 
@@ -633,8 +632,7 @@ module EvmState {
                 var exitCode := if vm.RETURNS? then 1 else 0;
                 // Extract return data (if applicable)
                 if vm.INVALID? then st.Push(0)
-                else if (outOffset + outSize) <= MAX_U256 && |vm.data| <= MAX_U256
-                then
+                else
                     // Determine amount of data to actually return
                     var m := Min(|vm.data|,outSize);
                     // Slice out that data
@@ -645,8 +643,6 @@ module EvmState {
                     var refund := if vm.RETURNS?||vm.REVERTS? then vm.gas else 0;
                     // Done
                     nst.Push(exitCode).Refund(refund).SetReturnData(vm.data).Copy(outOffset,data)
-                else
-                    INVALID(MEMORY_OVERFLOW)
             else
                 INVALID(STACK_UNDERFLOW)
         }
@@ -704,13 +700,10 @@ module EvmState {
                         var nworld := vm.world.SetCode(address,vm.data);
                         // Thread world state through
                         st.Refund(vm.gas - depositcost).Merge(nworld,vm.substate).Push(address as u256).SetReturnData([])
-                else if |vm.data| <= MAX_U256
-                then
+                else
                     // NOTE: in the event of a revert, the return data is
                     // provided back.
                     st.Refund(vm.gas).Push(0).SetReturnData(vm.data)
-                else
-                    INVALID(MEMORY_OVERFLOW)
             else
                 INVALID(STACK_UNDERFLOW)
         }

--- a/src/dafny/util/context.dfy
+++ b/src/dafny/util/context.dfy
@@ -89,8 +89,7 @@ module Context {
          * Determine the size (in bytes) of the return data from the previous call
          * associated with this context.
          */
-        function method ReturnDataSize() : nat
-        requires |this.returnData| <= MAX_U256 {
+        function method ReturnDataSize() : nat {
             |this.returnData|
         }
 
@@ -108,14 +107,13 @@ module Context {
         /**
          * Update the return data associated with this state.
          */
-        function method SetReturnData(data: seq<u8>) : Raw
-        requires |data| <= MAX_U256 {
+        function method SetReturnData(data: seq<u8>) : Raw {
            this.(returnData:=data)
         }
 
     }
 
-    type T = c:Raw | |c.callData| <= MAX_U256 && |c.returnData| <= MAX_U256
+    type T = c:Raw | |c.callData| <= MAX_U256
     witness Context(0,0,0,0,[],[],true,0,Info(0,0,0,0,0,0))
 
     /**

--- a/src/test/dafny/MemoryVerif.dfy
+++ b/src/test/dafny/MemoryVerif.dfy
@@ -39,7 +39,7 @@ abstract module MemoryVerif_01 {
     var address := vm.Peek(0) as nat;
 
     //  address + 31 bytes fit in memory iff Store is successful.
-    assert address + 31 < MAX_U256 <==>
+    assert address + 31 < MAX_U256 ==>
       !r.IsFailure() && U256.Read(r.evm.memory.contents, address) ==  vm.Peek(1);
 
     //  address + 31 bytes are already in memory. New state should be OK.
@@ -133,8 +133,8 @@ abstract module MemoryVerif_01 {
     var r := Bytecode.MLoad(vm);
     var address := vm.Peek(0) as nat;
 
-    //  address + 31 bytes fit in memory iff load is successful.
-    assert address + 31 < MAX_U256 <==>
+    //  address + 31 bytes fit in memory if load is successful.
+    assert address + 31 < MAX_U256 ==>
       !r.IsFailure() && r.Peek(0) == U256.Read(r.evm.memory.contents, address);
 
     //  address + 31 bytes are already in memory. New state should be OK.


### PR DESCRIPTION
The `MEMORY_OVERFLOW` is a ficticious exception create to appease Dafny in certain circumstances.  In particular, they Yellow Paper places no restrictions on the bounds of memory.  And yet, there are implied limits.  In particular, the `MSIZE` bytecode loads the length of memory onto the stack as a `u256`.  But, the yellow paper says nothing about what should happen in the event of an overflow.