### PR TITLE
Issue405/document the functions

### DIFF
--- a/src/dafny/state.dfy
+++ b/src/dafny/state.dfy
@@ -461,7 +461,9 @@ module EvmState {
          * Decode next opcode from machine.
          */
         function method Decode() : u8
-        requires !IsFailure() { Code.DecodeUint8(evm.code,evm.pc as nat) }
+            requires !IsFailure() 
+            ensures evm.pc > Code.Size(evm.code) as nat ==> Decode() == 0  
+        { Code.DecodeUint8(evm.code,evm.pc as nat) }
 
         /**
          * Decode next opcode from machine.

--- a/src/dafny/state.dfy
+++ b/src/dafny/state.dfy
@@ -478,7 +478,9 @@ module EvmState {
          * Move program counter to a given location.
          */
         function method Goto(k:u256) : State
-        requires !IsFailure() {
+        requires !IsFailure() 
+        ensures !Goto(k).IsFailure() && Goto(k).PC() <= MAX_U256 as nat
+        {
             State.OK(evm.(pc := k as nat))
         }
 

--- a/src/dafny/state.dfy
+++ b/src/dafny/state.dfy
@@ -584,8 +584,10 @@ module EvmState {
         /**
          * Check how many code operands are available.
          */
-        function method CodeOperands() : int
-        requires !IsFailure() {
+        function method CodeOperands(): nat
+        requires !IsFailure() 
+        requires evm.pc as nat + 1 <= Code.Size(evm.code) as nat
+        {
             (Code.Size(evm.code) as nat) - ((evm.pc as nat) + 1)
         }
 

--- a/src/test/dafny/Push.dfy
+++ b/src/test/dafny/Push.dfy
@@ -7,8 +7,8 @@ import opened Int
 // Some simple sanity tests to check equivalence of Push bytecodes.
 
 method test_1(s1: OKState, k:u8)
-requires s1.CodeOperands() >= 1
-requires DecodeUint8(s1.evm.code,s1.evm.pc+1) == k {
+requires DecodeUint8(s1.evm.code,s1.evm.pc+1) == k 
+{
     var s2 := Bytecode.Push1(s1,k);
     var s3 := EvmBerlin.Push(s1,1);
     // Should be identical
@@ -16,7 +16,6 @@ requires DecodeUint8(s1.evm.code,s1.evm.pc+1) == k {
 }
 
 method test_2(s1: OKState, k:u16)
-requires s1.CodeOperands() >= 2
 requires Bytes.ReadUint16(s1.evm.code.contents,s1.evm.pc+1) == k {
     var s2 := Bytecode.Push2(s1,k);
     var s3 := EvmBerlin.Push(s1,2);


### PR DESCRIPTION
Document the functions in `bytecode.dfy`.
Fixes #405 .