### PR TITLE
Fix #414

### DIFF
--- a/src/main/java/dafnyevm/DafnyEvm.java
+++ b/src/main/java/dafnyevm/DafnyEvm.java
@@ -39,6 +39,7 @@ import dafny.DafnyMap;
 import dafny.DafnySequence;
 import dafny.DafnySet;
 import dafny.Tuple2;
+import evmtools.util.Bytecodes;
 import evmtools.util.Hex;
 import dafnyevm.util.Word.Uint160;
 import dafnyevm.util.Word.Uint256;
@@ -351,7 +352,8 @@ public class DafnyEvm {
 		// Increment sender's nonce
 		ws = ws.IncNonce(sender);
 		// Begin the call.
-		EvmState_Compile.State st = EvmState_Compile.__default.Call(ws, ctx, ss, recipient, value, gas, BigInteger.ONE);
+        EvmState_Compile.State st = EvmState_Compile.__default.Call(ws, ctx, ss, recipient, value, gas,
+                BigInteger.ONE, (byte) Bytecodes.CALL);
 		// Execute bytecodes!
 		st = run(0, tracer, st);
 		// Convert back into the Java API
@@ -424,7 +426,17 @@ public class DafnyEvm {
 	 * @return
 	 */
 	private static EvmState_Compile.State callContinue(int depth, Tracer tracer, EvmState_Compile.State_CALLS cc) {
-		EvmState_Compile.State st = cc.CallEnter(BigInteger.valueOf(depth));
+	    // Determine opcode which lead to this call (e.g. CALL, DELEGATECALL, etc).
+	    int opcode = Code_Compile.__default.DecodeUint8(cc._evm._code, cc.PC().subtract(BigInteger.ONE)) & 0xff;
+	    // Sanity check precondition for CallEnter
+        if (opcode != Bytecodes.CALL && opcode != Bytecodes.DELEGATECALL && opcode != Bytecodes.CALLCODE
+                && opcode != Bytecodes.STATICCALL) {
+            throw new IllegalArgumentException("Invalid calling bytecode (" + Integer.toHexString(opcode) + ")");
+        } else if(!cc.Exists(cc._sender)) {
+            throw new IllegalArgumentException("Non-existent sender account!");
+        }
+	    //
+		EvmState_Compile.State st = cc.CallEnter(BigInteger.valueOf(depth), (byte) opcode);
 		// Run code within recursive call.
 		st = run(depth + 1, tracer, st);
 		// Return from call.

--- a/src/test/dafny/CallExample.dfy
+++ b/src/test/dafny/CallExample.dfy
@@ -53,7 +53,7 @@ module CallExamples {
         vm1 := Call(vm1);
         // >>> Contract call starts here
         {
-            var vm2 := vm1.CallEnter(1);
+            var vm2 := vm1.CallEnter(1, Opcode.CALL);
             vm2 := Pop(vm2); // force exception
             vm1 := vm1.CallReturn(vm2);
         }

--- a/src/test/java/dafnyevm/GeneralStateTests.java
+++ b/src/test/java/dafnyevm/GeneralStateTests.java
@@ -121,14 +121,6 @@ public class GeneralStateTests {
 			"stCreateTest/CREATE_ContractRETURNBigOffset.json", // large return?
 			"VMTests/vmArithmeticTest/exp.json", // too slow?
 			"stSStoreTest/InitCollisionNonZeroNonce.json",
-			"stStaticCall/static_callBasic.json",
-			"stStaticCall/static_callcallcallcode_001_2.json",
-			"stStaticCall/static_callcallcode_01_2.json",
-			"stStaticCall/static_callcallcodecall_010_2.json",
-			"stStaticCall/static_callcallcodecallcode_011_2.json",
-			"stStaticCall/static_callcodecallcallcode_101_2.json",
-			"stStaticCall/static_callcodecallcallcode_ABCB_RECURSIVE2.json",
-			"stStaticCall/static_CallContractToCreateContractWhichWouldCreateContractIfCalled.json",
 			"stStaticCall/static_CallEcrecover0_0input.json",
 			"stStaticCall/static_CallEcrecover0_completeReturnValue.json",
 			"stStaticCall/static_CallEcrecover0_Gas2999.json",
@@ -160,8 +152,6 @@ public class GeneralStateTests {
 			"stStaticCall/StaticcallToPrecompileFromCalledContract.json",
 			"stStaticCall/StaticcallToPrecompileFromContractInitialization.json",
 			"stStaticCall/StaticcallToPrecompileFromTransaction.json",
-			"stStaticCall/static_CheckOpcodes2.json",
-			"stStaticCall/static_CheckOpcodes3.json",
 			"dummy"
 	);
 


### PR DESCRIPTION
This puts through a fix for write permissions and the CALLCODE instruction.  Specifically, write permission as related to value transfer are only relevant for the CALL bytecode.