### PR TITLE
Fix #372

### DIFF
--- a/src/dafny/state.dfy
+++ b/src/dafny/state.dfy
@@ -691,7 +691,7 @@ module EvmState {
             if st.Capacity() >= 1
             then
                 // Extract return data (if applicable)
-                if vm.INVALID? then st.Push(0)
+                if vm.INVALID? then st.AccountAccessed(address).Push(0)
                 else if vm.RETURNS?
                 then
                     // Calculate the deposit cost
@@ -711,7 +711,7 @@ module EvmState {
                 else
                     // NOTE: in the event of a revert, the return data is
                     // provided back.
-                    st.Refund(vm.gas).Push(0).SetReturnData(vm.data)
+                    st.Refund(vm.gas).AccountAccessed(address).Push(0).SetReturnData(vm.data)
             else
                 INVALID(STACK_OVERFLOW)
         }

--- a/src/test/java/dafnyevm/GeneralStateTests.java
+++ b/src/test/java/dafnyevm/GeneralStateTests.java
@@ -108,7 +108,6 @@ public class GeneralStateTests {
 	        "stCreate2/create2callPrecompiles.json", // #266 (address 0x1)
 			"stReturnDataTest/modexp_modsize0_returndatasize.json", // #371
 			"stReturnDataTest/revertRetDataSize.json", // #371
-	        "stCreateTest/CreateCollisionResults.json", // #372
 	        "stBadOpcode/undefinedOpcodeFirstByte.json", // #413
 			// Unknowns
 	        "stBadOpcode/invalidAddr.json",


### PR DESCRIPTION
This puts through a fix for contract creations (e.g. for `CREATE` or `CREATE2`).  The issue was that, even after a failed contract creation, the account that was attempted to be created is marked as WARM.