### PR TITLE
Issue459/Investigate-the-verification-issue-when-using-`bv`

### DIFF
--- a/src/dafny/bytecode.dfy
+++ b/src/dafny/bytecode.dfy
@@ -490,7 +490,7 @@ module Bytecode {
     /**
      * Right shift operation.
      */
-    function method {:verify false} Shr(st: State) : State
+    function method {:verify true} Shr(st: State) : State
     requires st.IsExecuting() {
         //
         if st.Operands() >= 2

--- a/src/dafny/bytecode.dfy
+++ b/src/dafny/bytecode.dfy
@@ -426,13 +426,14 @@ module Bytecode {
     /**
     * Bitwise XOR operation.
     */
-    function method {:verify false} Xor(st: State) : State
+    function method {:verify true} Xor(st: State) : State
     requires st.IsExecuting() {
         //
         if st.Operands() >= 2
         then
             var lhs := st.Peek(0) as bv256;
             var rhs := st.Peek(1) as bv256;
+            U256.as_bv256_as_u256(lhs ^ rhs);
             var res := (lhs ^ rhs) as u256;
             st.Pop().Pop().Push(res).Next()
         else

--- a/src/dafny/bytecode.dfy
+++ b/src/dafny/bytecode.dfy
@@ -409,7 +409,7 @@ module Bytecode {
     /**
     * Bitwise OR operation.
     */
-    function method {:verify true} Or(st: State) : State
+    function method Or(st: State) : State
     requires st.IsExecuting() {
         //
         if st.Operands() >= 2
@@ -426,7 +426,7 @@ module Bytecode {
     /**
     * Bitwise XOR operation.
     */
-    function method {:verify true} Xor(st: State) : State
+    function method Xor(st: State) : State
     requires st.IsExecuting() {
         //
         if st.Operands() >= 2
@@ -490,7 +490,7 @@ module Bytecode {
     /**
      * Right shift operation.
      */
-    function method {:verify true} Shr(st: State) : State
+    function method Shr(st: State) : State
     requires st.IsExecuting() {
         //
         if st.Operands() >= 2

--- a/src/dafny/bytecode.dfy
+++ b/src/dafny/bytecode.dfy
@@ -409,13 +409,14 @@ module Bytecode {
     /**
     * Bitwise OR operation.
     */
-    function method {:verify false} Or(st: State) : State
+    function method {:verify true} Or(st: State) : State
     requires st.IsExecuting() {
         //
         if st.Operands() >= 2
         then
             var lhs := st.Peek(0) as bv256;
             var rhs := st.Peek(1) as bv256;
+            U256.as_bv256_as_u256(lhs | rhs);
             var res := (lhs | rhs) as u256;
             st.Pop().Pop().Push(res).Next()
         else

--- a/src/dafny/util/int.dfy
+++ b/src/dafny/util/int.dfy
@@ -552,6 +552,22 @@ module I256 {
         Int.Rem(lhs as int, rhs as int) as i256
     }
 
+    /**
+     *  Shifting 1 left less than 256 times produces a non-zero value.
+     *
+     *  More generally, shifting-left 1 less than k times over k bits 
+     *  yield a non-zero number.
+     *
+     *  @example    over 2 bits, left-shift 1 once: 01 -> 10
+     *  @example    over 4 bits, left-shift 1 3 times: 0001 -> 0010 -> 0100 -> 1000
+     */
+    lemma ShiftYieldsNonZero(x: u256) 
+        requires 0 < x < 256 
+        ensures U256.Shl(1, x) > 0 
+    {
+        //  Thanks Dafny.
+    }
+
     // Shift Arithmetic Right.  This implementation follows the Yellow Paper quite
     // accurately.
     function method {:verify false} Sar(lhs: i256, rhs: u256) : i256 {

--- a/src/dafny/util/int.dfy
+++ b/src/dafny/util/int.dfy
@@ -416,7 +416,12 @@ module U256 {
     import U64
     import U128
 
-    function method Shl(lhs: u256, rhs: u256) : u256 {
+    /** An axiom stating that a bv256 converted as a nat is bounded by 2^256. */
+    lemma {:axiom} as_bv256_as_u256(v: bv256)
+        ensures v as nat < TWO_256
+
+    function method Shl(lhs: u256, rhs: u256) : u256 
+    {
         var lbv := lhs as bv256;
         // NOTE: unclear whether shifting is optimal choice here.
         var res := if rhs < 256 then (lbv << rhs) else 0;

--- a/src/dafny/util/int.dfy
+++ b/src/dafny/util/int.dfy
@@ -570,11 +570,13 @@ module I256 {
 
     // Shift Arithmetic Right.  This implementation follows the Yellow Paper quite
     // accurately.
-    function method {:verify false} Sar(lhs: i256, rhs: u256) : i256 {
+    function method Sar(lhs: i256, rhs: u256): i256 {
         if rhs == 0 then lhs
         else if rhs < 256
         then
+            assert 0 < rhs < 256;
             var r := U256.Shl(1,rhs);
+            ShiftYieldsNonZero(rhs);
             ((lhs as int) / (r as int)) as i256
         else if lhs < 0 then -1
         else 0


### PR DESCRIPTION
Make bitwise operations verifiable. Some bitwise operations in the `Bytecode` module were previously tagged `:verify false` which means that Dafny did not verify them.
This PR provides some missing axioms and proofs to make them verifiable.