### PR TITLE
Increase available RAM during testing #460

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,6 +82,8 @@ test {
     inputs.files(fileTree('tests') { include '**/*.json' } )
     // Ensure can see stdout
     testLogging.showStandardStreams = true
+    // Ensure enough memory
+    jvmArgs '-Xmx2G'
     //
     useJUnitPlatform()
     filter {


### PR DESCRIPTION
This increases the amount of available RAM during testing, as this currently requires at least 2G to succeed.