### PR TITLE
Reorganise source structure

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3,76 +3,74 @@
 1. [Overview](#overview)
 1. [Architecture](#repoArch)
 1. [Source Files](#sourceFilesi)
-	1. [Top Layer Files](#top)
-	1. [Middle Layer Files](#mid)
-	1. [Low Layer Files](#low)
+	1. [High Level](#top)
+	1. [Mid Level](#mid)
+	1. [Low Level](#low)
 
 
 # Overview
 
 The [evm-dafny](https://github.com/ConsenSys/evm-dafny) repository contains five directories and five stand-alone files the most remarkable of which are the following:
 
-- [`github/workflows`](https://github.com/ConsenSys/evm-dafny/tree/master/.github/workflows) consists of the build process of different modules and their dependencies,
-- [`fixture`](https://github.com/ethereum/tests/tree/9d91961e98e97ba319e089f31388d4685da9b362) contains the ethereum tests to generate, to test our system against,
+- [`github/workflows`](.github/workflows) consists of the build process of different modules and their dependencies,
+- [`fixtures`](https://github.com/ethereum/tests/tree/9d91961e98e97ba319e089f31388d4685da9b362) contains the ethereum tests to generate, to test our system against,
 
-- [`resources`](https://github.com/ConsenSys/evm-dafny/tree/master/resources) contains the log of tests which have been generated and our system is tested against,
+- [`resources`](resources) contains the log of tests which have been generated and our system is tested against,
 
-- [`src`](https://github.com/ConsenSys/evm-dafny/tree/master/src) comprises the backbone of our system including the formal semantics of the Dafny-EVM. It contains three subdirectories:
-	
-	- [`dafny`](https://github.com/ConsenSys/evm-dafny/tree/master/src/dafny) consists of the Dafny-EVM Source Files as explained further below,
-	- [`main`](https://github.com/ConsenSys/evm-dafny/tree/master/src/main/java) includes the Java interface to the Dafny,
-	- [`test`](https://github.com/ConsenSys/evm-dafny/tree/master/src/test) contains simple tests implemented in dafny for checking the correctness of different opcodes  
+- [`src`](src) comprises the backbone of our system including the formal semantics of the Dafny-EVM. It contains three subdirectories:
 
-- [`tests`](https://github.com/ConsenSys/evm-dafny/tree/master/tests) consists of the list of ethereum tests we are currently running,
+	- [`dafny`](src/dafny) consists of the Dafny-EVM Source Files as explained further below,
+	- [`main`](src/main/java) includes the Java interface to the Dafny,
+	- [`test`](src/test) contains simple tests implemented in dafny for checking the correctness of different opcodes
+
+- [`tests`](tests) consists of the list of ethereum tests we are currently running,
 
 
-- [`build.gradle`](https://github.com/ConsenSys/evm-dafny/blob/master/build.gradle) consists of build instructions with the `gradle` tool,
- 
-We organize the [Source Files](#sourceFiles) of the Dafny-EVM according to a three-layer architecture explained further below. 
+- [`build.gradle`](build.gradle) consists of build instructions with the `gradle` tool,
+
+We organize the [Source Files](#sourceFiles) of the Dafny-EVM according to a three-layer architecture explained further below.
 # Architecture
 
-The architecture of the [Source Files](#sourceFiles) comprises the three layers; top, middle and the bottom layer, as shown in the image below. The top of the stack image, shows the [Top layer] modules containing bytecode semantics and top-level types.  We locate in the middle of the image, modules of the [Middle Layer](#mid) which contain abstractions of the main components.  The bottom of the stack depicts the modules placed at the [Bottom Layer](#low) which specify fundamental primitives (e.g. for manipulating bytes and ints). 
+The architecture of the [Source Files](#sourceFiles) comprises the three layers; top, middle and the bottom layer, as shown in the image below. The top of the stack image, shows the [High Level] modules containing bytecode semantics and top-level types.  We locate in the middle of the image, modules of the [Middle Level](#mid) which contain abstractions of the main components.  The bottom of the stack depicts the modules placed at the [Low Level](#low) which specify fundamental primitives (e.g. for manipulating bytes and ints).
 
 <p align="center">
-    <img width="450" src="https://github.com/ConsenSys/evm-dafny/blob/master/resources/stackArch.png" alt="Dafny-EVM Architecture">
+    <img width="450" src="resources/stackArch.png" alt="Dafny-EVM Architecture">
 </p>
 
 
 # Source Files
 
-The source files including our formalisation of the EVM semantics, the state, gas calculations, and helper modules appear under the directory [`src/dafny`](https://github.com/ConsenSys/evm-dafny/tree/master/src/dafny). The architecture of the source files accords with the three layer model explained above. 
+The source files including our formalisation of the EVM semantics, the state, gas calculations, and helper modules appear under the directory [`src/dafny`](/src/dafny). The architecture of the source files accords with the three layer model explained above.
 
-## Top Layer
+## High Level
 
-- [`evms`](https://github.com/ConsenSys/evm-dafny/tree/master/src/dafny/evms) contains modules each of which specify an extension of our EVM with a particular hardfork of users' choice, for example [`berlin.dfy`](https://github.com/ConsenSys/evm-dafny/tree/master/src/dafny/evms/berlin.dfy).
+- [`evms`](src/dafny/evms) contains modules each of which specify an extension of our EVM with a particular hardfork of users' choice, for example [`berlin.dfy`](src/dafny/evms/berlin.dfy).
 
-- [`opcodes.dfy`](https://github.com/ConsenSys/evm-dafny/blob/master/src/dafny/opcodes.dfy) encodes all of the EVM opcodes.
+- [`opcodes.dfy`](src/dafny/opcodes.dfy) encodes all of the EVM opcodes.
 
-- [`evm.dfy`](https://github.com/ConsenSys/evm-dafny/blob/master/src/dafny/evm.dfy) provides a generic mechanism for building extensions on our EVM based on a hardfork of users' choice.
+- [`evm.dfy`](src/dafny/evm.dfy) provides a generic mechanism for building extensions on our EVM based on a hardfork of users' choice.
 
-- [`state.dfy`](https://github.com/ConsenSys/evm-dafny/blob/master/src/dafny/state.dfy) specifies various EVM states and how to perform operations on them.
+- [`state.dfy`](src/dafny/state.dfy) specifies various EVM states and how to perform operations on them.
 
-- [`bytecode.dfy`](https://github.com/ConsenSys/evm-dafny/blob/master/src/dafny/bytecode.dfy) includes the implementation of the EVM opcodes' semantics.
+- [`bytecode.dfy`](src/dafny/bytecode.dfy) includes the implementation of the EVM opcodes' semantics.
 
-- [`gas.dfy`](https://github.com/ConsenSys/evm-dafny/blob/master/src/dafny/gas.dfy) specifies gas charging calculations.
-
-
-## Middle Layer 
-- [`code.dfy`](https://github.com/ConsenSys/evm-dafny/blob/master/src/dafny/util/code.dfy) is an implementation of read-only code region of the EVM.
-- [`context.dfy`](https://github.com/ConsenSys/evm-dafny/blob/master/src/dafny/util/context.dfy) implements the execution context of a transaction.
-- [`memory.dfy`](https://github.com/ConsenSys/evm-dafny/blob/master/src/dafny/util/memory.dfy) is a specification of the EVM's volatile memory.
-- [`precompiled.dfy`](https://github.com/ConsenSys/evm-dafny/blob/master/src/dafny/util/precompiled.dfy) implements precompiled contracts.
-- [`stack.dfy`](https://github.com/ConsenSys/evm-dafny/blob/master/src/dafny/util/stack.dfy) specifies the stack of EVM together with stack operations.
-- [`storage.dfy`](https://github.com/ConsenSys/evm-dafny/blob/master/src/dafny/util/storage.dfy) is an implementation of the EVM storage including functionalities for performing operations on the storage.
-- [`substate.dfy`](https://github.com/ConsenSys/evm-dafny/blob/master/src/dafny/util/substate.dfy) encodes the substate of the EVM.
-- [`worldstate.dfy`](https://github.com/ConsenSys/evm-dafny/blob/master/src/dafny/util/worldstate.dfy) specifies the wold state of the ethereum.
+- [`gas.dfy`](src/dafny/gas.dfy) specifies gas charging calculations.
 
 
-## Bottom Layer
+## Mid Level
+- [`code.dfy`](src/dafny/core/code.dfy) is an implementation of read-only code region of the EVM.
+- [`context.dfy`](src/dafny/core/context.dfy) implements the execution context of a transaction.
+- [`memory.dfy`](src/dafny/core/memory.dfy) is a specification of the EVM's volatile memory.
+- [`precompiled.dfy`](src/dafny/core/precompiled.dfy) implements precompiled contracts.
+- [`stack.dfy`](src/dafny/core/stack.dfy) specifies the stack of EVM together with stack operations.
+- [`storage.dfy`](src/dafny/core/storage.dfy) is an implementation of the EVM storage including functionalities for performing operations on the storage.
+- [`substate.dfy`](src/dafny/core/substate.dfy) encodes the substate of the EVM.
+- [`worldstate.dfy`](src/dafny/core/worldstate.dfy) specifies the wold state of the ethereum.
 
-- [`ExtraTypes.dfy`](https://github.com/ConsenSys/evm-dafny/blob/master/src/dafny/util/ExtraTypes.dfy)
-- [`bytes.dfy`](https://github.com/ConsenSys/evm-dafny/blob/master/src/dafny/util/bytes.dfy) implements an specification of machine bytes together with methods for performing operations on them.
-- [`int.dfy`](https://github.com/ConsenSys/evm-dafny/blob/master/src/dafny/util/int.dfy) specifies machine words of various length both signed and unsigned.
-- [`extern.dfy`](https://github.com/ConsenSys/evm-dafny/blob/master/src/dafny/util/extern.dfy) interfaces Dafny with Java.
 
+## Low Level
 
+- [`option.dfy`](src/dafny/util/option.dfy)
+- [`bytes.dfy`](src/dafny/util/bytes.dfy) implements an specification of machine bytes together with methods for performing operations on them.
+- [`int.dfy`](src/dafny/util/int.dfy) specifies machine words of various length both signed and unsigned.
+- [`extern.dfy`](src/dafny/util/extern.dfy) interfaces Dafny with Java.

--- a/src/dafny/bytecode.dfy
+++ b/src/dafny/bytecode.dfy
@@ -23,7 +23,7 @@ module Bytecode {
     import External
     import GasCalc = Gas
     import opened EvmState
-    import opened ExtraTypes
+    import opened Optional
 
     // =====================================================================
     // 0s: Stop and Arithmetic Operations
@@ -1141,7 +1141,7 @@ module Bytecode {
     /**
      *  Marks a valid destination for a jump, but otherwise has no effect
      *  on machine state, except incrementing PC.
-     *  Equivalent to SKIP instruction semantics-wise. 
+     *  Equivalent to SKIP instruction semantics-wise.
      */
     function method JumpDest(st: State) : State
     requires st.IsExecuting() {
@@ -1154,27 +1154,27 @@ module Bytecode {
 
     /**
      *  Push bytes on the stack.
-     *  
+     *
      *  @param st   A state.
      *  @param k    The number of bytes to push.
      *
-     *  @note       The semantics of the EVM does not seem to require 
+     *  @note       The semantics of the EVM does not seem to require
      *              that k bytes are following the current OPCODE, PUSHk.
      *              So a number of bytes is read and left-padded if not enough
      *              are after PUSHk, and a value is pushed on the stack even
      *              not enough (< k) bytes are available in the code after PUSHk.
-     *              As the PC is advanced by k, the next PC will be outside 
+     *              As the PC is advanced by k, the next PC will be outside
      *              the code range, and the next opcode to be executed will be defaulted
      *              to 0 (zero) which is the STOP opcode.
-     *              In summary: if m < k bytes are following a PUSHk opcode, 
-     *              a zero-left-padded value of m bytes is pushed on the stack, and 
+     *              In summary: if m < k bytes are following a PUSHk opcode,
+     *              a zero-left-padded value of m bytes is pushed on the stack, and
      *              the next instruction is STOP.
      */
     function method Push(st: State, k: nat) : State
-    requires k > 0 && k <= 32 
+    requires k > 0 && k <= 32
     requires st.IsExecuting()
     {
-        if st.Capacity() >= 1 
+        if st.Capacity() >= 1
         then
             var bytes := Code.Slice(st.evm.code, (st.evm.pc+1), k);
             assert 0 < |bytes| <= 32;
@@ -1184,7 +1184,7 @@ module Bytecode {
             State.INVALID(STACK_OVERFLOW)
     }
 
-    
+
     /**
      * Push one byte onto stack.
      */

--- a/src/dafny/core/code.dfy
+++ b/src/dafny/core/code.dfy
@@ -11,8 +11,8 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-include "bytes.dfy"
-include "int.dfy"
+include "../util/bytes.dfy"
+include "../util/int.dfy"
 
 module Code {
   import Bytes

--- a/src/dafny/core/context.dfy
+++ b/src/dafny/core/context.dfy
@@ -11,8 +11,8 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-include "int.dfy"
-include "bytes.dfy"
+include "../util/int.dfy"
+include "../util/bytes.dfy"
 
 module Context {
     import opened Int

--- a/src/dafny/core/memory.dfy
+++ b/src/dafny/core/memory.dfy
@@ -11,8 +11,8 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-include "int.dfy"
-include "bytes.dfy"
+include "../util/int.dfy"
+include "../util/bytes.dfy"
 
 /**
  * Memory on the EVM is a byte-addressable (volatile) random access memory.

--- a/src/dafny/core/precompiled.dfy
+++ b/src/dafny/core/precompiled.dfy
@@ -11,17 +11,17 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-include "bytes.dfy"
-include "extern.dfy"
-include "int.dfy"
-include "ExtraTypes.dfy"
+include "../util/bytes.dfy"
+include "../util/extern.dfy"
+include "../util/int.dfy"
+include "../util/option.dfy"
 
 /**
  * Interface for the so-called "precompiled contracts".
  */
 module Precompiled {
     import opened Int
-    import opened ExtraTypes
+    import opened Optional
     import U32
     import U256
     import External

--- a/src/dafny/core/stack.dfy
+++ b/src/dafny/core/stack.dfy
@@ -11,7 +11,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-include "int.dfy"
+include "../util/int.dfy"
 
 module Stack {
     import opened Int
@@ -27,7 +27,7 @@ module Stack {
     witness Stack([])
 
     const Empty := Stack([])
-    
+
     // Get number of items currently on this Stack.
     function method Size(st:T) : nat { |st.contents| }
 
@@ -87,7 +87,7 @@ module Stack {
 
     /** Swap top item at index 0 and the k+1-th item at index k. */
     function method Swap(st:T, k:nat) : T
-      requires Size(st) > k > 0 
+      requires Size(st) > k > 0
     {
         var top := st.contents[0];
         var kth := st.contents[k];
@@ -101,7 +101,7 @@ module Stack {
      *  @param  u   An index.
      *  @returns    The stack made of the first u elements minus the first l.
      */
-    function Slice(st: T, l: nat, u: nat): (r:T)  
+    function Slice(st: T, l: nat, u: nat): (r:T)
         requires l <= u <= Size(st)
     {
         Stack(st.contents[l..u])

--- a/src/dafny/core/storage.dfy
+++ b/src/dafny/core/storage.dfy
@@ -11,7 +11,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-include "int.dfy"
+include "../util/int.dfy"
 
 /**
  * Storage on the EVM is a word-addressable (non-volatile) random access memory.

--- a/src/dafny/core/substate.dfy
+++ b/src/dafny/core/substate.dfy
@@ -11,7 +11,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-include "int.dfy"
+include "../util/int.dfy"
 
 module SubState {
      import opened Int

--- a/src/dafny/core/worldstate.dfy
+++ b/src/dafny/core/worldstate.dfy
@@ -11,11 +11,11 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-include "int.dfy"
 include "code.dfy"
-include "ExtraTypes.dfy"
 include "storage.dfy"
-include "extern.dfy"
+include "../util/int.dfy"
+include "../util/option.dfy"
+include "../util/extern.dfy"
 
 /**
  * World state provides a snapshot of all accounts on the blockchain at a given
@@ -24,7 +24,7 @@ include "extern.dfy"
 module WorldState {
     import opened Int
     import Code
-    import opened ExtraTypes
+    import opened Optional
     import Storage
     import External
 

--- a/src/dafny/evm.dfy
+++ b/src/dafny/evm.dfy
@@ -12,7 +12,7 @@
  * under the License.
  */
 include "state.dfy"
-include "util/ExtraTypes.dfy"
+include "util/option.dfy"
 
 /**
  * Top-level definition of an Ethereum Virtual Machine.
@@ -20,7 +20,7 @@ include "util/ExtraTypes.dfy"
 abstract module EVM {
     import opened EvmState
     import opened Int
-    import opened ExtraTypes
+    import opened Optional
 
     /** The semantics of opcodes.
      *

--- a/src/dafny/evms/berlin.dfy
+++ b/src/dafny/evms/berlin.dfy
@@ -27,7 +27,7 @@ module EvmBerlin refines EVM {
      */
     function method InitEmpty(gas: nat, code: seq<u8> := []) : (st:State)
         requires |code| <= Code.MAX_CODE_SIZE
-        ensures st.IsExecuting() 
+        ensures st.IsExecuting()
     {
         var tx := Context.Create(0,0,0,0,[],true,0,Context.Block.Info(0,0,0,0,0,0));
         Create(tx, map[0:=WorldState.DefaultAccount()], gas, code)
@@ -216,5 +216,5 @@ module EvmBerlin refines EVM {
             case _ => s
     }
 
-    
+
 }

--- a/src/dafny/gas.dfy
+++ b/src/dafny/gas.dfy
@@ -14,19 +14,19 @@
 include "util/int.dfy"
 include "opcodes.dfy"
 include "state.dfy"
-include "util/ExtraTypes.dfy"
-include "util/memory.dfy"
+include "core/memory.dfy"
+include "core/code.dfy"
+include "core/context.dfy"
+include "core/worldstate.dfy"
+include "core/substate.dfy"
+include "util/option.dfy"
 include "util/bytes.dfy"
-include "util/code.dfy"
-include "util/context.dfy"
-include "util/worldstate.dfy"
-include "util/substate.dfy"
 
 module Gas {
 	import opened Opcode
 	import opened EvmState
     import opened Int
-    import opened ExtraTypes
+    import opened Optional
     import opened Memory
     import opened Bytes
     import opened Code

--- a/src/dafny/state.dfy
+++ b/src/dafny/state.dfy
@@ -11,18 +11,18 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-include "util/int.dfy"
-include "util/memory.dfy"
-include "util/context.dfy"
-include "util/code.dfy"
+include "core/memory.dfy"
+include "core/precompiled.dfy"
+include "core/stack.dfy"
+include "core/context.dfy"
+include "core/code.dfy"
+include "core/storage.dfy"
+include "core/substate.dfy"
+include "core/worldstate.dfy"
 include "util/extern.dfy"
-include "util/precompiled.dfy"
-include "util/storage.dfy"
-include "util/stack.dfy"
-include "util/substate.dfy"
-include "util/worldstate.dfy"
+include "util/option.dfy"
+include "util/int.dfy"
 include "opcodes.dfy"
-include "util/ExtraTypes.dfy"
 
 /**
  *  Provide State type to encode the current state of the EVM.
@@ -38,7 +38,7 @@ module EvmState {
     import Code
     import Opcode
     import Precompiled
-    import opened ExtraTypes
+    import opened Optional
 
     /**
      * Following included from gas.dfy to avoid circular definition.  However,
@@ -169,7 +169,7 @@ module EvmState {
         /**
          * Determine number of operands on stack.
          */
-        function method Operands() : nat 
+        function method Operands() : nat
         requires IsExecuting() {
             Stack.Size(evm.stack)
         }
@@ -546,7 +546,7 @@ module EvmState {
         }
 
         /**
-         *  Extract a slice of the stack. 
+         *  Extract a slice of the stack.
          *
          *  @param  l   An index.
          *  @param  u   An index.
@@ -554,10 +554,10 @@ module EvmState {
          */
         function SlicePeek(l: nat, u: nat): (r: Stack.T)
         requires IsExecuting()
-        requires l <= u <= Stack.Size(evm.stack) 
+        requires l <= u <= Stack.Size(evm.stack)
         ensures Stack.Size(r) == u - l
-        { 
-            Stack.Slice(evm.stack, l, u)  
+        {
+            Stack.Slice(evm.stack, l, u)
         }
 
         /**
@@ -732,19 +732,19 @@ module EvmState {
         }
 
         /** The opcode at a given index in the code.
-         *  
+         *
          *  Following the EVM convention, if index is outside the range of code,
          *  returns STOP.
          */
-        function CodeAtIndex(index: nat): u8 
+        function CodeAtIndex(index: nat): u8
         requires IsExecuting() {
-            if index < Code.Size(evm.code) as nat then 
-                Code.CodeAt(evm.code, index) 
-            else 
+            if index < Code.Size(evm.code) as nat then
+                Code.CodeAt(evm.code, index)
+            else
                 Opcode.STOP
         }
 
-        function CodeAtPC(): u8 
+        function CodeAtPC(): u8
         requires IsExecuting() { CodeAtIndex(PC()) }
 
         /**

--- a/src/dafny/util/option.dfy
+++ b/src/dafny/util/option.dfy
@@ -12,7 +12,7 @@
  * under the License.
  */
 
-module ExtraTypes {
+module Optional {
 
     datatype Option<T> = Some(v: T) | None {
         /**

--- a/src/main/java/dafnyevm/DafnyEvm.java
+++ b/src/main/java/dafnyevm/DafnyEvm.java
@@ -501,7 +501,7 @@ public class DafnyEvm {
 	 * @return
 	 */
 	public static BigInteger addr(BigInteger sender, BigInteger nonce) {
-		byte[] hash = addr(sender,nonce,new ExtraTypes_Compile.Option_None<>(),null);
+		byte[] hash = addr(sender,nonce,new Optional_Compile.Option_None<>(),null);
 		return new BigInteger(1,hash);
 	}
 
@@ -516,18 +516,18 @@ public class DafnyEvm {
 	 * @param initCode The initialisation code (only used with salt).
 	 * @return
 	 */
-	public static byte[] addr(BigInteger sender, BigInteger nonce, ExtraTypes_Compile.Option<BigInteger> salt,
+	public static byte[] addr(BigInteger sender, BigInteger nonce, Optional_Compile.Option<BigInteger> salt,
 			DafnySequence<? extends Byte> initCode) {
 		byte[] bytes;
 		//
-		if (salt instanceof ExtraTypes_Compile.Option_None) {
+		if (salt instanceof Optional_Compile.Option_None) {
 			// Case for CREATE
 			bytes = new Uint160(sender).getBytes();
 			bytes = RlpEncoder.encode(new RlpList(RlpString.create(bytes),RlpString.create(nonce)));
 		} else {
 			@SuppressWarnings({ "rawtypes", "unchecked" })
 			byte[] code = DafnySequence.toByteArray((DafnySequence) initCode);
-			ExtraTypes_Compile.Option_Some<BigInteger> s = (ExtraTypes_Compile.Option_Some<BigInteger>) salt;
+			Optional_Compile.Option_Some<BigInteger> s = (Optional_Compile.Option_Some<BigInteger>) salt;
 			// Case for CREATE2 (see EIP 1014).
 			byte ff = (byte) (0xff & 0xff);
 			byte[] senderBytes = new Uint160(sender).getBytes();


### PR DESCRIPTION
This creates a directory `core/` into which core EVM primitives are moved.  The result is that primitives in `util/` are not specifically EVM primitives, but more general primitives.