### PR TITLE
Issue480/Add-formal-proofs-of-bytecode-optimisations

### DIFF
--- a/src/dafny/bytecode.dfy
+++ b/src/dafny/bytecode.dfy
@@ -229,7 +229,9 @@ module Bytecode {
     }
 
     /**
-     * Unsigned integer modulo multiplication.
+     *  Unsigned integer modulo multiplication.
+     * 
+     *  if Peek(2) == 0 then 0 else (Peek(0) * Peek(1)) % Peek(2)
      */
     function method MulMod(st: State) : State
     requires st.IsExecuting() {

--- a/src/dafny/bytecode.dfy
+++ b/src/dafny/bytecode.dfy
@@ -1215,6 +1215,19 @@ module Bytecode {
             State.INVALID(STACK_OVERFLOW)
     }
 
+    /** 
+     *  Push 32 bytes on the stack.
+     */
+    function method Push32(st: State, k: u256) : State
+    requires st.IsExecuting() {
+        //
+        if st.Capacity() >= 1
+        then
+            st.Push(k).Skip(3)
+        else
+            State.INVALID(STACK_OVERFLOW)
+    }
+
     // =====================================================================
     // 80s: Duplication Operations
     // =====================================================================

--- a/src/dafny/evm.dfy
+++ b/src/dafny/evm.dfy
@@ -46,12 +46,13 @@ abstract module EVM {
      * Create a fresh EVM to execute a given sequence of bytecode instructions.
      * The EVM is initialised with an empty stack and empty local memory.
      */
-    function method Create(context: Context.T, world: map<u160,WorldState.Account>, gas: nat, code: seq<u8>) : State
+    function method Create(context: Context.T, world: map<u160,WorldState.Account>, gas: nat, code: seq<u8>, st: seq<u256> := []) : State
     // Code to executed cannot exceed maximum limit.
     requires |code| <= Code.MAX_CODE_SIZE
+    requires |st| <= 1024
     // Account under which EVM is executing must exist!
     requires context.address in world {
-        var stck := Stack.Create();
+        var stck := Stack.Make(st);
         var mem := Memory.Create();
         var wld := WorldState.Create(world);
         var cod := Code.Create(code);
@@ -72,6 +73,11 @@ abstract module EVM {
         match st.OpDecode()
           case Some(opcode) => OpSem(opcode, OpGas(opcode, st))
           case None => State.INVALID(INVALID_OPCODE)
+    }
+
+    function method ExecuteOP(st: State, op: u8): State
+    {
+          OpSem(op, OpGas(op, st))
     }
 
     /**

--- a/src/dafny/evms/berlin.dfy
+++ b/src/dafny/evms/berlin.dfy
@@ -33,6 +33,20 @@ module EvmBerlin refines EVM {
         Create(tx, map[0:=WorldState.DefaultAccount()], gas, code)
     }
 
+    /** An empty VM, with some initial gas and initial stack.
+     *
+     *  @param  gas     The gas loaded in this EVM.
+     *  @returns        An ready-to-use EVM.
+     */
+    function method Init(gas: nat, stk: seq<u256> := [], code: seq<u8> := []) : (st:State)
+        requires |code| <= Code.MAX_CODE_SIZE
+        requires |stk| <= 1024
+        ensures st.IsExecuting()
+    {
+        var tx := Context.Create(0,0,0,0,[],true,0,Context.Block.Info(0,0,0,0,0,0));
+        Create(tx, map[0:=WorldState.DefaultAccount()], gas, code, stk)
+    }
+
     /** The gas cost semantics of an opcode.
      *
      *  @param op   The opcode to look up.

--- a/src/test/dafny/Optimisations.dfy
+++ b/src/test/dafny/Optimisations.dfy
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2022 ConsenSys Software Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software dis-
+ * tributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+include "../../dafny/evms/berlin.dfy"
+
+/** Provide some tests to check some qualitative properties of bytecode.
+ *
+ *  We use an EVM with no gas as the bytecode high-level instructions
+ *  like `Push1` do not consume gas.
+ */
+module Optimisations {
+
+    import opened Int
+    import opened Bytecode
+    import opened EvmBerlin
+    import opened EvmState
+    import opened Opcode
+    import Stack
+
+    //  Some optimisation examples from 
+    // https://fenix.tecnico.ulisboa.pt/cursos/mma/dissertacao/1691203502343808
+
+    /**
+     *  Proposition 12: n + 1 consecutive Pop  <_gas SwapN n + 1 consecutive Pop
+     *  Gas cost for POP is G_BASE and for SWAP G_VERYLOW
+     *  
+     *  @param  s   An initial stack content.
+     *  @param  g   An initial value of gas.
+     * 
+     *  @note   Case n = 1
+     */
+    method Proposition12a(s: seq<u256>, g: nat)
+        /** Stack must have at least 2 elements. */
+        requires 2 <= |s| <= 1024   
+        /** Minimum gas needed. */
+        requires g >= 2 * Gas.G_BASE + Gas.G_VERYLOW
+    {
+        var vm := EvmBerlin.Init(gas := g, stk := s, code := []);
+        //  execute 2 POPs
+        var vm1 := vm;
+        vm1 := ExecuteOP(vm1, POP);
+        vm1 := ExecuteOP(vm1, POP);
+
+        //  execute SWAP1 and 2 POPs
+        var vm2 := vm;
+        vm2 := ExecuteOP(vm2, SWAP1);
+        vm2 := ExecuteOP(vm2, POP);
+        vm2 := ExecuteOP(vm2, POP);
+
+        //  States are the same except for gas and PC
+        assert vm1.evm.(pc := 0, gas := 0) == vm2.evm.(pc := 0, gas :=0);
+        //  Gas saved is Gas.G_VERYLOW
+        assert vm2.Gas() < vm1.Gas();
+    }    
+
+    /**
+     *  
+     *  Proposition 12: n + 1 consecutive Pop  <_gas SwapN n + 1 consecutive Pop
+     *  Gas cost for POP is G_BASE and for SWAP G_VERYLOW
+     *  
+     *  @param  n   As described above.
+     *  @param  s   An initial stack content.
+     *  @param  g   An initial value of gas.
+     *
+     *  @note       General case.
+     *
+     */
+    method Proposition12b(n: nat, s: seq<u256>, g: nat)
+        requires 1 <= n <= 16 
+        /** Stack must have at least n + 1 elements. */
+        requires n + 1 <= |s| <= 1024
+        /** Minimum gas needed. */
+        requires g >= (n + 1) * Gas.G_BASE + Gas.G_VERYLOW
+    {
+        var vm := EvmBerlin.Init(gas := g, stk := s, code := []);
+
+        //  Execute n POPs in vm1.
+        var vm1 := vm;
+        for i := 0 to n + 1
+            invariant vm1.OK?
+            invariant vm1.Gas() == g - i * Gas.G_BASE
+            invariant vm1.Operands() >= n - i
+            invariant vm1.GetStack() == vm.SlicePeek(i, |s|)
+        {
+            vm1 := ExecuteOP(vm1, POP);
+            assert vm1.OK?;
+        }
+        assert vm1.Gas() >= Gas.G_VERYLOW;
+        //  Stack after n POPs is suffix of initial stack starting at index n + 1
+        assert vm1.GetStack() == vm.SlicePeek(n + 1, |s|);
+
+        //  Execute SWAPn and then n POPs in vm2. 
+        var vm2 := vm;
+        vm2 := Swap(vm2, n).UseGas(Gas.G_VERYLOW);
+
+        for i := 0 to n + 1
+            invariant vm2.OK? 
+            invariant vm2.Gas() == g - i * Gas.G_BASE - Gas.G_VERYLOW
+            invariant vm2.Operands() >= n + 1 - i
+            invariant vm2.Operands() == vm.Operands() - i == |s| - i
+            invariant vm2.SlicePeek(n + 1 - i, |s| - i) == vm.SlicePeek(n + 1, |s|)
+        {
+            vm2 := ExecuteOP(vm2, POP);
+            assert vm2.OK?;
+        }
+        assert vm2.SlicePeek(0, |s| - n - 1) == vm.SlicePeek(n + 1, |s|);
+        assert vm1.GetStack() == vm2.GetStack();
+        assert vm2.Gas() == vm1.Gas() -  Gas.G_VERYLOW;
+        assert vm2.Gas() < vm1.Gas();
+    }    
+}


### PR DESCRIPTION
Add an example of a proof of correctness for an optimisation pattern.
see #480