### PR TITLE
Update to Dafny 3.10.0 #496

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Dafny
         uses: dafny-lang/setup-dafny-action@v1
         with:
-          dafny-version: "3.8.1"
+          dafny-version: "3.10.0"
 
       - name: Z3 version
         continue-on-error: true

--- a/src/main/java/dafnyevm/DafnyEvm.java
+++ b/src/main/java/dafnyevm/DafnyEvm.java
@@ -321,8 +321,8 @@ public class DafnyEvm {
 	}
 
 	public DafnyEvm create(BigInteger address, BigInteger nonce, BigInteger endowment, Map<BigInteger, BigInteger> storage, byte[] bytecode) {
-		Storage_Compile.T store = Storage_Compile.T.create(new DafnyMap<BigInteger,BigInteger>(storage));
-		Code_Compile.Raw code = new Code_Compile.Raw(DafnySequence.fromBytes(bytecode));
+		DafnyMap<BigInteger,BigInteger> store = new DafnyMap<BigInteger,BigInteger>(storage);
+		DafnySequence<Byte> code = DafnySequence.fromBytes(bytecode);
 		WorldState_Compile.Account acct = WorldState_Compile.__default.CreateAccount(nonce, endowment, store,code);
 		this.worldState = DafnyMap.update(worldState, address, acct);
 		return this;
@@ -675,7 +675,7 @@ public class DafnyEvm {
 			@SuppressWarnings("unchecked")
 			public byte[] getMemory() {
 				@SuppressWarnings("rawtypes")
-				DafnySequence bytes = getEVM().dtor_memory().dtor_contents();
+				DafnySequence bytes = getEVM().dtor_memory();
 				return DafnySequence.toByteArray(bytes);
 			}
 
@@ -685,7 +685,7 @@ public class DafnyEvm {
 			 * @return
 			 */
 			public int getMemorySize() {
-				return getEVM().dtor_memory().dtor_contents().length();
+				return getEVM().dtor_memory().length();
 			}
 
 			/**
@@ -694,7 +694,7 @@ public class DafnyEvm {
 			 * @return
 			 */
 			public BigInteger[] getStack() {
-				DafnySequence<? extends BigInteger> dStack = getEVM().dtor_stack().dtor_contents();
+				DafnySequence<? extends BigInteger> dStack = getEVM().dtor_stack();
 				BigInteger[] rStack = new BigInteger[dStack.length()];
 				final int n = rStack.length;
 				// NOTE: this is necessary because the stack is actually maintained "backwards"
@@ -717,7 +717,7 @@ public class DafnyEvm {
 				// Get account record
 				WorldState_Compile.Account a = getEVM().dtor_world().dtor_accounts().get(address);
 				// Extract storage
-				DafnyMap<? extends BigInteger, ? extends BigInteger> m = a.dtor_storage().dtor_contents();
+				DafnyMap<? extends BigInteger, ? extends BigInteger> m = a.dtor_storage();
 				// Copy over
 				m.forEach((k,v) -> storage.put(k,v));
 				return storage;
@@ -887,9 +887,9 @@ public class DafnyEvm {
 			for (BigInteger account : accounts.keySet().Elements()) {
 				Account a = accounts.get(account);
 				@SuppressWarnings({ "rawtypes", "unchecked" })
-				byte[] bytecode = DafnySequence.toByteArray((DafnySequence) a.dtor_code().dtor_contents());
+				byte[] bytecode = DafnySequence.toByteArray((DafnySequence) a.dtor_code());
 				Map<BigInteger, BigInteger> store = new HashMap<>();
-				DafnyMap<? extends BigInteger, ? extends BigInteger> m = a.dtor_storage().dtor_contents();
+				DafnyMap<? extends BigInteger, ? extends BigInteger> m = a.dtor_storage();
 				// Copy over
 				m.forEach((k, v) -> store.put(k, v));
 				ws.put(account, new evmtools.core.Account(a.dtor_balance(), a.dtor_nonce(), store, bytecode));


### PR DESCRIPTION
This updates the default Dafny version for building the Dafny EVM to be 3.10.0.  In particular, that required fixing some compatibility issues introduced (see below).  The Github Action is also updated accordingly.

The compatability problem appears to be a change in the way that Dafny compiles `datatype` instances into Java.  For example, previously the Dafny type `Storage.T` was represented using a Java class `T` which wrapped a `DafnyMap`.  Now (for whatever reason), `Storage.T` is represented directly as a `DafnyMap`.  Presumably this is only happens when the `datatype` has only a single case (which `Storage.T` does).