### PR TITLE
Remove `MEMORY_OVERFLOW` from `ReturnDataSize` #513

### DIFF
--- a/src/dafny/bytecode.dfy
+++ b/src/dafny/bytecode.dfy
@@ -967,18 +967,14 @@ module Bytecode {
      */
     function method ReturnDataSize(st: State): (st': State)
     requires st.IsExecuting()
-    ensures st'.OK? || st' == INVALID(STACK_OVERFLOW) || st' == INVALID(MEMORY_OVERFLOW)
-    ensures st'.OK? <==> st.Capacity() >= 1 && st.evm.context.ReturnDataSize() <= MAX_U256
+    ensures st'.OK? || st' == INVALID(STACK_OVERFLOW)
+    ensures st'.OK? <==> st.Capacity() >= 1
     ensures st'.OK? ==> st'.Operands() == st.Operands() + 1
     {
         if st.Capacity() >= 1
         then
             var len := st.evm.context.ReturnDataSize();
-            if len <= MAX_U256
-            then
-                st.Push(len as u256).Next()
-            else
-                State.INVALID(MEMORY_OVERFLOW)
+            st.Push(len).Next()
         else
             State.INVALID(STACK_OVERFLOW)
     }
@@ -990,7 +986,7 @@ module Bytecode {
     requires st.IsExecuting()
     ensures st'.OK? || st' == INVALID(STACK_UNDERFLOW) || st' == INVALID(RETURNDATA_OVERFLOW)
     ensures st'.OK? <==> st.Operands() >= 3 &&
-                        (st.Peek(1) as nat + st.Peek(2) as nat) <= st.evm.context.ReturnDataSize()
+                         (st.Peek(1) as nat + st.Peek(2) as nat) <= st.evm.context.ReturnDataSize() as nat
     ensures st'.OK? ==> st'.Operands() == st.Operands() - 3
     {
         //
@@ -999,7 +995,7 @@ module Bytecode {
             var m_loc := st.Peek(0) as nat;
             var d_loc := st.Peek(1) as nat;
             var len := st.Peek(2) as nat;
-            if (d_loc + len) <= st.evm.context.ReturnDataSize()
+            if (d_loc + len) <= (st.evm.context.ReturnDataSize() as nat)
             then
                 // Slice bytes out of return data (with padding as needed)
                 var data := st.evm.context.ReturnDataSlice(d_loc,len);

--- a/src/dafny/core/context.dfy
+++ b/src/dafny/core/context.dfy
@@ -89,8 +89,9 @@ module Context {
          * Determine the size (in bytes) of the return data from the previous call
          * associated with this context.
          */
-        function method ReturnDataSize() : nat {
-            |this.returnData|
+        function method ReturnDataSize() : u256
+        requires |this.returnData| < TWO_256 {
+            |this.returnData| as u256
         }
 
         /**
@@ -113,7 +114,7 @@ module Context {
 
     }
 
-    type T = c:Raw | |c.callData| <= MAX_U256
+    type T = c:Raw | |c.callData| <= MAX_U256 && |c.returnData| <= MAX_U256
     witness Context(0,0,0,0,[],[],true,0,Info(0,0,0,0,0,0))
 
     /**

--- a/src/dafny/evmstate.dfy
+++ b/src/dafny/evmstate.dfy
@@ -47,6 +47,14 @@ module EvmState {
     const G_CODEDEPOSIT: nat := 200;
 
     /**
+     * A fixed size array which is bounded by the maximum word size.  Thus, it
+     * represents an array (e.g. of bytes) which could appear as part of the EVM
+     * state (e.g. CALLDATA or RETURDATA).  Thus, the length of the array can be
+     * reasonably turned into a u256 and (for example) loaded on the stack.
+     */
+    type Array<T> = arr:seq<T> | |arr| < TWO_256
+
+    /**
      *  A normal state.
      *
      *  @param  context     An execution context (initiator, etc)
@@ -148,8 +156,8 @@ module EvmState {
             salt: Option<u256>  // optional salt
         )
         | INVALID(Error)
-        | RETURNS(gas:nat,data:seq<u8>,world: WorldState.T,substate:SubState.T)
-        | REVERTS(gas:nat,data:seq<u8>){
+        | RETURNS(gas:nat,data: Array<u8>,world: WorldState.T,substate:SubState.T)
+        | REVERTS(gas:nat,data: Array<u8>){
 
         /**
          * Check whether EVM is in an execution state or not (e.g. because its
@@ -614,7 +622,8 @@ module EvmState {
          * Update the return data associated with this state.
          */
         function method SetReturnData(data: seq<u8>) : State
-        requires IsExecuting() {
+        requires IsExecuting()
+        requires |data| < TWO_256 {
             OK(evm.(context:=evm.context.SetReturnData(data)))
         }
 


### PR DESCRIPTION
This pushes through a useful simplification.