### PR TITLE
Move Memory.ReadUint256/WriteUint256 into Bytes

### DIFF
--- a/src/dafny/core/memory.dfy
+++ b/src/dafny/core/memory.dfy
@@ -98,130 +98,21 @@ module Memory {
     // =============================================================================
 
     /**
-     * Read the byte at a given address in Memory.  If the given location
-     * has not been initialised, then zero is returned as default.
-     */
-    function ReadUint8(mem:T, address:nat) : u8 {
-        // Read location
-        if address < |mem.contents|
-        then
-          mem.contents[address]
-        else
-          0
-    }
-
-    /**
-     * Read a 16bit word from a given address in Memory assuming
-     * big-endian addressing.
-     */
-    function ReadUint16(mem:T, address:nat) : u16
-      requires address + 1 < |mem.contents| {
-        var w1 := ReadUint8(mem,address) as u16;
-        var w2 := ReadUint8(mem,address+1) as u16;
-        (w1 * (TWO_8 as u16)) + w2
-    }
-
-    /**
-     * Read a 32bit word from a given address in Memory assuming
-     * big-endian addressing.
-     */
-    function ReadUint32(mem:T, address:nat) : u32
-      requires address + 3 < |mem.contents| {
-        var w1 := ReadUint16(mem,address) as u32;
-        var w2 := ReadUint16(mem,address+2) as u32;
-        (w1 * (TWO_16 as u32)) + w2
-    }
-
-    /**
-     * Read a 64bit word from a given address in Memory assuming
-     * big-endian addressing.
-     */
-    function ReadUint64(mem:T, address:nat) : u64
-      requires address + 7 < |mem.contents| {
-        var w1 := ReadUint32(mem,address) as u64;
-        var w2 := ReadUint32(mem,address+4) as u64;
-        (w1 * (TWO_32 as u64)) + w2
-    }
-
-    /**
-     * Read a 128bit word from a given address in Memory assuming
-     * big-endian addressing.
-     */
-    function ReadUint128(mem:T, address:nat) : u128
-      requires address + 15 < |mem.contents| {
-        var w1 := ReadUint64(mem,address) as u128;
-        var w2 := ReadUint64(mem,address+8) as u128;
-        (w1 * (TWO_64 as u128)) + w2
-    }
-
-    /**
      * Read a 256bit word from a given address in Memory assuming
      * big-endian addressing.
      */
     function ReadUint256(mem:T, address:nat) : u256
       requires address + 31 < |mem.contents| {
-        var w1 := ReadUint128(mem,address) as u256;
-        var w2 := ReadUint128(mem,address+16) as u256;
-        (w1 * (TWO_128 as u256)) + w2
+       Bytes.ReadUint256(mem.contents,address)
     }
 
     /**
      * Write a byte to a given address in Memory.
      */
-
     function WriteUint8(mem:T, address:nat, val:u8) : T
-        requires address < |mem.contents| {
-        // Update size calc.
+    requires address < |mem.contents| {
         // Write location
         Memory(contents:=mem.contents[address:=val])
-    }
-
-    /**
-     * Write a 16bit word to a given address in Memory using
-     * big-endian addressing.
-     */
-    function WriteUint16(mem:T, address:nat, val:u16) : T
-    requires address + 1 < |mem.contents| {
-      var w1 := val / (TWO_8 as u16);
-      var w2 := val % (TWO_8 as u16);
-      var mem' := WriteUint8(mem,address,w1 as u8);
-      WriteUint8(mem',address+1,w2 as u8)
-    }
-
-    /**
-     * Write a 32bit word to a given address in Memory using
-     * big-endian addressing.
-     */
-    function WriteUint32(mem:T, address:nat, val:u32) : T
-    requires address + 3 < |mem.contents| {
-      var w1 := val / (TWO_16 as u32);
-      var w2 := val % (TWO_16 as u32);
-      var mem' := WriteUint16(mem,address,w1 as u16);
-      WriteUint16(mem',address+2,w2 as u16)
-    }
-
-    /**
-     * Write a 64bit word to a given address in Memory using
-     * big-endian addressing.
-     */
-    function WriteUint64(mem:T, address:nat, val:u64) : T
-    requires address + 7 < |mem.contents| {
-      var w1 := val / (TWO_32 as u64);
-      var w2 := val % (TWO_32 as u64);
-      var mem' := WriteUint32(mem,address,w1 as u32);
-      WriteUint32(mem',address+4,w2 as u32)
-    }
-
-    /**
-     * Write a 128bit word to a given address in Memory using
-     * big-endian addressing.
-     */
-    function WriteUint128(mem:T, address:nat, val:u128) : T
-    requires address + 15 < |mem.contents| {
-      var w1 := val / (TWO_64 as u128);
-      var w2 := val % (TWO_64 as u128);
-      var mem' := WriteUint64(mem,address,w1 as u64);
-      WriteUint64(mem',address+8,w2 as u64)
     }
 
     /**
@@ -230,11 +121,10 @@ module Memory {
      */
     function WriteUint256(mem:T, address:nat, val:u256) : (mem':T)
     requires address + 31 < |mem.contents|
+    // Nothing has changed except the bytes overwritten by the u256
     ensures Arrays.EqualsExcept(mem.contents,mem'.contents,address,32) {
-      var w1 := val / (TWO_128 as u256);
-      var w2 := val % (TWO_128 as u256);
-      var mem' := WriteUint128(mem,address,w1 as u128);
-      WriteUint128(mem',address+16,w2 as u128)
+        var ncontents := Bytes.WriteUint256(mem.contents,address,val);
+        Memory(contents:=ncontents)
     }
 
     /**

--- a/src/dafny/util/bytes.dfy
+++ b/src/dafny/util/bytes.dfy
@@ -83,6 +83,75 @@ module Bytes {
         (w1 * (TWO_128 as u256)) + w2
     }
 
+    /**
+     * Write a byte to a given address in Memory.
+     */
+    function WriteUint8(mem:seq<u8>, address:nat, val:u8) : seq<u8>
+        requires address < |mem| {
+        // Write location
+        mem[address:=val]
+    }
+
+    /**
+     * Write a 16bit word to a given address in Memory using
+     * big-endian addressing.
+     */
+    function WriteUint16(mem:seq<u8>, address:nat, val:u16) : seq<u8>
+    requires address + 1 < |mem| {
+      var w1 := val / (TWO_8 as u16);
+      var w2 := val % (TWO_8 as u16);
+      var mem' := WriteUint8(mem,address,w1 as u8);
+      WriteUint8(mem',address+1,w2 as u8)
+    }
+
+    /**
+     * Write a 32bit word to a given address in Memory using
+     * big-endian addressing.
+     */
+    function WriteUint32(mem:seq<u8>, address:nat, val:u32) : seq<u8>
+    requires address + 3 < |mem| {
+      var w1 := val / (TWO_16 as u32);
+      var w2 := val % (TWO_16 as u32);
+      var mem' := WriteUint16(mem,address,w1 as u16);
+      WriteUint16(mem',address+2,w2 as u16)
+    }
+
+    /**
+     * Write a 64bit word to a given address in Memory using
+     * big-endian addressing.
+     */
+    function WriteUint64(mem:seq<u8>, address:nat, val:u64) : seq<u8>
+    requires address + 7 < |mem| {
+      var w1 := val / (TWO_32 as u64);
+      var w2 := val % (TWO_32 as u64);
+      var mem' := WriteUint32(mem,address,w1 as u32);
+      WriteUint32(mem',address+4,w2 as u32)
+    }
+
+    /**
+     * Write a 128bit word to a given address in Memory using
+     * big-endian addressing.
+     */
+    function WriteUint128(mem:seq<u8>, address:nat, val:u128) : seq<u8>
+    requires address + 15 < |mem| {
+      var w1 := val / (TWO_64 as u128);
+      var w2 := val % (TWO_64 as u128);
+      var mem' := WriteUint64(mem,address,w1 as u64);
+      WriteUint64(mem',address+8,w2 as u64)
+    }
+
+    /**
+     * Write a 256bit word to a given address in Memory using
+     * big-endian addressing.
+     */
+    function WriteUint256(mem:seq<u8>, address:nat, val:u256) : (mem':seq<u8>)
+    requires address + 31 < |mem|{
+      var w1 := val / (TWO_128 as u256);
+      var w2 := val % (TWO_128 as u256);
+      var mem' := WriteUint128(mem,address,w1 as u128);
+      WriteUint128(mem',address+16,w2 as u128)
+    }
+
     /** Converts a sequence of bytes into a u256.
      *
      *  @param  bytes   A sequence of bytes.


### PR DESCRIPTION
This moves the various methods allowing us to read/write `u256` words from byte sequences into the `Bytes` module where they logically belong.