### PR TITLE
Revert Github Action to Dafny 3.13.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Dafny
         uses: dafny-lang/setup-dafny-action@v1.6.1
         with:
-          dafny-version: "4.0.0"
+          dafny-version: "3.13.0"
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -16,7 +16,7 @@ MAKEFLAGS += --warn-undefined-variables --no-builtin-rules
 #each target has its own parallelism too, so keep a low number of jobs
 MAKEFLAGS += -j 2 #--output-sync
 RUN_ARGS ?=
-DAFNY_ARGS := --cores 50%
+DAFNY_ARGS := --function-syntax 4 --quantifier-syntax 4 --cores 50%
 
 #silent by default
 SILENCER := @
@@ -79,7 +79,7 @@ dafny_test_global: $(DAFNY_TEST_WITNESS_GLOBAL) $(DAFNY_VERIFY_WITNESS_GLOBAL)
 #TODO probably tests should refer to the main build instead of rebuilding it (once the Dafny toolchain supports it)
 $(DAFNY_TEST_WITNESS_GLOBAL): $(DAFNY_TEST_FILES)
 	@echo Testing Dafny : `echo $? | wc -w` files
-	$(SILENCER)$(DAFNY_EXEC)  /vcsLoad:2  /compileTarget:go /compile:4 /compileVerbose:0 /noExterns /out:$(DAFNY_TEST_OUT_DIR)/global $? /runAllTests:1  /warnShadowing /deprecation:2 #$(DAFNY_ARGS)
+	$(SILENCER)$(DAFNY_EXEC) /functionSyntax:4 /quantifierSyntax:4 /vcsLoad:2 /compileTarget:go /compile:4 /compileVerbose:0 /noExterns /out:$(DAFNY_TEST_OUT_DIR)/global $? /runAllTests:1  /warnShadowing /deprecation:2 #$(DAFNY_ARGS)
 #	Dafny v4 new CLI: test doesn't seem to work
 #	$(SILENCER)$(DAFNY_EXEC) test $(DAFNY_ARGS) --test-assumptions Externs  --target go --warn-shadowing  --resource-limit 100000  $< # --output $(DAFNY_TEST_OUT_DIR)/$*
 	$(SILENCER)touch $@
@@ -100,7 +100,7 @@ dafny_translate: $(DAFNY_OUT_FILENAME) $(DAFNY_TEST_WITNESS_GLOBAL)
 
 $(DAFNY_OUT_FILENAME) : $(DAFNY_SRC_FILES)
 	@echo Translating Dafny
-	$(SILENCER)$(DAFNY_EXEC) /rlimit:100000 /vcsLoad:2 /compileTarget:go /compileVerbose:0 /spillTargetCode:3 /noExterns /warnShadowing /deprecation:2 /out:$(DAFNY_OUT_ARG) $(DAFNY_SRC_ENTRY_POINT) /compile:2 #$(DAFNY_ARGS)
+	$(SILENCER)$(DAFNY_EXEC) /functionSyntax:4 /quantifierSyntax:4 /rlimit:100000 /vcsLoad:2 /compileTarget:go /compileVerbose:0 /spillTargetCode:3 /noExterns /warnShadowing /deprecation:2 /out:$(DAFNY_OUT_ARG) $(DAFNY_SRC_ENTRY_POINT) /compile:2 #$(DAFNY_ARGS)
 #	Dafny v4 new CLI: missing --deprecation and --noExterns
 #	$(SILENCER)$(DAFNY_EXEC) build $(DAFNY_ARGS) --no-verify --target go --warn-shadowing --test-assumptions Externs --output:$(DAFNY_OUT_ARG) $(DAFNY_SRC_ENTRY_POINT) #--deprecation 2  -noExterns
 

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,9 @@ final DAFNY_BASE_FLAGS = [
     '/compileVerbose:0',
     '/noExterns',
     '/vcsLoad:2',
-    '/rlimit:1000000'
+    '/rlimit:1000000',
+    '/functionSyntax','4',
+    '/quantifierSyntax','4'
 ]
 
 final DAFNY_BUILD_FLAGS = DAFNY_BASE_FLAGS + [

--- a/src/dafny/util/int.dfy
+++ b/src/dafny/util/int.dfy
@@ -593,7 +593,7 @@ module I256 {
   // language) supports Euclidean division.  Observe that this is a
   // true Remainder operator, and not a modulus operator.  For
   // emxaple, this means the result can be negative.
-  function {:verify false} Rem(lhs: i256, rhs: i256) : i256
+  function Rem(lhs: i256, rhs: i256) : i256
     // Cannot divide by zero!
     requires rhs != 0 {
     Int.Rem(lhs as int, rhs as int) as i256

--- a/src/test/dafny/proofs/FM-paper.dfy
+++ b/src/test/dafny/proofs/FM-paper.dfy
@@ -46,7 +46,7 @@ module Kontract1 {
     /**
      *  Simple proof about a contract reverting if oevrflows.
      */
-    method {:verify false} inc_proof(st: ExecutingState) returns (st': State)
+    method inc_proof(st: ExecutingState) returns (st': State)
         /** Initial state with PC = 0 and empty stack. */
         requires st.PC() == 0 && st.Operands() == 0
         /** Enough gas. */
@@ -116,7 +116,7 @@ module Kontract1 {
      *  @note       The check relies on the property specified by lemma AddOverflowNSC.
      *  @note       The overflow is specified as x + y exceeding MAX_U256.
      */
-    method {:verify false} OverflowCheck(st: ExecutingState, x: u256, y: u256) returns (st': State)
+    method OverflowCheck(st: ExecutingState, x: u256, y: u256) returns (st': State)
         /** OK state and initial PC.  */
         requires /* Pre0 */ st.PC() == 0
         /** Enough gas. Longest path gas-wise is via JUMPI. */
@@ -161,7 +161,7 @@ module Kontract1 {
      *              The stack content is unconstrained but there must be
      *              enough capacity (3) to perform this computation.
      */
-    method {:verify false} Loopy(st: ExecutingState, c: u8) returns (st': State)
+    method Loopy(st: ExecutingState, c: u8) returns (st': State)
         requires /* Pre0 */ st.PC() == 0 && st.Capacity() >= 3
         requires /* Pre1 */ st.Gas() >=
             3 * Gas.G_VERYLOW + Gas.G_JUMPDEST +

--- a/src/test/dafny/proofs/SimulationProof.dfy
+++ b/src/test/dafny/proofs/SimulationProof.dfy
@@ -44,7 +44,7 @@ function equiv(l: State, r: State) : bool {
         false
 }
 
-method {:verify false} proof(context: Context.T, world: map<u160,WorldState.Account>, gas: nat)
+method proof(context: Context.T, world: map<u160,WorldState.Account>, gas: nat)
 requires context.writePermission
 requires gas > 100000
 requires context.address in world {

--- a/src/test/dafny/proofs/Test10-with-gas.dfy
+++ b/src/test/dafny/proofs/Test10-with-gas.dfy
@@ -172,7 +172,7 @@ module Test10Gas {
      *  @param  c   The number of times to iterate the loop.
      *  @param  g   The initial amount of gas.
      */
-    method {:verify false} main5(c: u8, g: nat)
+    method main5(c: u8, g: nat)
         requires g >= G_BASE + 4 * G_VERYLOW + c as nat * (2 * G_BASE + 9 * G_VERYLOW)
     {
         // Initialise Bytecode

--- a/src/test/dafny/proofs/test.dfy
+++ b/src/test/dafny/proofs/test.dfy
@@ -27,7 +27,7 @@ module Test {
      *  1. execution can go through
      *  2. the gas left at the end of the program.
      */
-    method {:verify false} Test_EVM_01(x: u8)
+    method Test_EVM_01(x: u8)
     {
         // Initialise Bytecode
         var vm := EvmBerlin.InitEmpty(


### PR DESCRIPTION
This reverts the Github action to use Dafny 3.13.0.  Since that version of Dafny uses Z3 v4.8.5, a bunch of things which were marked `{:verify false}` will now verify again and have been unmarked.