### PR TITLE
Fixes for State.ERROR Default Arguments

### DIFF
--- a/src/dafny/evm.dfy
+++ b/src/dafny/evm.dfy
@@ -72,7 +72,7 @@ abstract module EVM {
     {
         match st.OpDecode()
             case Some(op) => ExecuteOP(st,op)
-            case None => ERROR(INVALID_OPCODE,0,[])
+            case None => ERROR(INVALID_OPCODE)
     }
 
     function ExecuteOP(st: ExecutingState, op: u8): State {

--- a/src/dafny/evmstate.dfy
+++ b/src/dafny/evmstate.dfy
@@ -644,7 +644,7 @@ module EvmState {
         var address := ctx.address;
         // Check call depth & available balance.  Note there isn't an off-by-one
         // error here (even though it looks like it).
-        if depth > 1024 || !world.CanWithdraw(ctx.sender,value) then ERROR(REVERTS, gas, [])
+        if depth > 1024 || !world.CanWithdraw(ctx.sender,value) then ERROR(REVERTS, gas)
         else
             // Create default account (if none exists)
             var w := world.EnsureAccount(address);
@@ -659,10 +659,10 @@ module EvmState {
                 then
                     // Call precompiled contract
                     match precompiled.Call(codeAddress,ctx.callData)
-                    case None => ERROR(INVALID_PRECONDITION,0,[])
+                    case None => ERROR(INVALID_PRECONDITION)
                     case Some((data,gascost)) => if gas >= gascost
                         then RETURNS(gas - gascost, data, nw, substate)
-                        else ERROR(INSUFFICIENT_GAS,0,[])
+                        else ERROR(INSUFFICIENT_GAS)
                 // Check for end-user account
                 else
                     // Extract contract code
@@ -692,9 +692,9 @@ module EvmState {
         var endowment := ctx.callValue;
         // Check call depth & available balance. Note there isn't an off-by-one
         // error here (even though it looks like it).
-        if depth > 1024 || !world.CanWithdraw(ctx.sender,endowment) || !ctx.writePermission then ERROR(REVERTS,gas,[])
+        if depth > 1024 || !world.CanWithdraw(ctx.sender,endowment) || !ctx.writePermission then ERROR(REVERTS,gas)
         // Sanity checks for existing account
-        else if world.Exists(ctx.address) && !world.CanOverwrite(ctx.address) then ERROR(ACCOUNT_COLLISION,0,[])
+        else if world.Exists(ctx.address) && !world.CanOverwrite(ctx.address) then ERROR(ACCOUNT_COLLISION)
         else
             var storage := Storage.Create(map[]); // empty
             var account := WorldState.CreateAccount(1,endowment,storage,Code.Create([]),WorldState.HASH_EMPTYCODE);

--- a/src/dafny/gas.dfy
+++ b/src/dafny/gas.dfy
@@ -754,6 +754,6 @@ module Gas {
             case STATICCALL => s.UseGas(CostExpandDoubleRange(s,6,2,3,4,5) + StaticCallCost(s))
             case REVERT => s.UseGas(CostExpandRange(s,2,0,1) + G_ZERO)
             case SELFDESTRUCT => s.UseGas(CostSelfDestruct(s))
-            case _ => ERROR(INVALID_OPCODE,0,[])
+            case _ => ERROR(INVALID_OPCODE)
     }
 }


### PR DESCRIPTION
This removes unnecessary uses of default arguments in the context of `State.ERROR`.