### PR TITLE
Implement `alt_bn128` multiplication

### DIFF
--- a/src/dafny/crypto/alt_bn128.dfy
+++ b/src/dafny/crypto/alt_bn128.dfy
@@ -123,6 +123,18 @@ module EllipticCurve refines FiniteField {
             else
                 INFINITY
     }
+
+    // Multiply a point by a given factor on the curve.
+    function PointMul(p: Point, n: u256) : (r:Point)
+    requires N > 3 && IsPrime(N)
+    decreases n
+    {
+        if n == 0 then INFINITY
+        else
+            var res := PointMul(PointAdd(p,p),n / 2);
+            if n % 2 == 1 then PointAdd(res,p)
+            else res
+    }
 }
 
 // The ellptic curve given by y^2 == x^3 + 3.

--- a/src/test/java/dafnyevm/GeneralStateTests.java
+++ b/src/test/java/dafnyevm/GeneralStateTests.java
@@ -114,10 +114,10 @@ public class GeneralStateTests {
             "StaticcallToPrecompileFromTransaction_Berlin_0_0_0",
             "precompsEIP2929_Berlin_0_(43|61|151|169|241|295)_0",
             "idPrecomps_Berlin_0_[4-7]_0",
-            "ecmul_.*",
+            //"ecmul_.*",
             "ecpairing.*",
             "pairingTest.*",
-            "pointMulAdd.*",
+            //"pointMulAdd.*",
             // #455
             "MSTORE_Bounds2_Berlin_(0|1)_0_0",
             "modexp_Berlin_[0123]_(2|28|29|30|36|37)_0", // int overflow


### PR DESCRIPTION
This puts through the multiplication primitive, which essentially just calls out to the point-wise addition primitive.