### PR TITLE
Implement `Int.ModPow()`

### DIFF
--- a/src/dafny/util/int.dfy
+++ b/src/dafny/util/int.dfy
@@ -158,6 +158,29 @@ module Int {
         }
     }
 
+    /**
+     * Compute n^k % m.  This is more efficient that doing Pow(n,k) % m.  In
+     * particular, we break out the primary case where the exponent is even.
+     */
+    function {:inline} ModPow(n:nat, k:nat, m:nat) : (r:nat)
+    requires m > 0
+    ensures r < m
+    ensures n > 0 ==> r >= 0
+    decreases k {
+        var nm := n % m;
+        if k == 0 || m == 1 then 1%m
+        else if k == 1 then nm
+        else
+            var np := ModPow(nm,k/2,m);
+            var np2 := (np * np) % m;
+            if (k%2) == 0 then
+                // Even case.  n^2k = n^k * n^k
+                np2
+            else
+                // Odd case.  n^2k+1 = n^2k * n
+                (np2 * nm) % m
+    }
+
     // Euclid's extended GCD algorithm, implemented recursively.
     function GcdExtended(a: nat, b: nat) : (r:(nat,int,int))
     // Conditions under which gcd is non-zero

--- a/src/test/dafny/tests/IntTests.dfy
+++ b/src/test/dafny/tests/IntTests.dfy
@@ -92,6 +92,38 @@ module IntTests {
         AssertAndExpect((TWO_256 / TWO_128) == TWO_128);
     }
 
+    // Various sanity tests for modulo exponentiation.
+    method {:test} ModPowTests() {
+        AssertAndExpect(ModPow(1,1,2) == 1);
+        AssertAndExpect(ModPow(2,2,2) == 0);
+        AssertAndExpect(ModPow(2,2,3) == 1);
+        AssertAndExpect(ModPow(2,2,4) == 0);
+        AssertAndExpect(ModPow(2,2,5) == 4);
+        AssertAndExpect(ModPow(2,2,6) == 4);
+        AssertAndExpect(ModPow(3,2,2) == 1);
+        AssertAndExpect(ModPow(3,2,3) == 0);
+        AssertAndExpect(ModPow(3,2,4) == 1);
+        AssertAndExpect(ModPow(3,2,5) == 4);
+        AssertAndExpect(ModPow(3,2,6) == 3);
+        AssertAndExpect(ModPow(3,2,7) == 2);
+        AssertAndExpect(ModPow(3,2,8) == 1);
+        AssertAndExpect(ModPow(3,2,9) == 0);
+        AssertAndExpect(ModPow(2,3,2) == 0);
+        AssertAndExpect(ModPow(2,0,256) == 1);
+        AssertAndExpect(ModPow(2,1,256) == 2);
+        AssertAndExpect(ModPow(2,2,256) == 4);
+        AssertAndExpect(ModPow(2,3,256) == 8);
+        AssertAndExpect(ModPow(2,4,256) == 16);
+        AssertAndExpect(ModPow(2,8,256) == 0);
+        AssertAndExpect(ModPow(2,9,256) == 0);
+        AssertAndExpect(ModPow(3,0,256) == 1);
+        AssertAndExpect(ModPow(3,1,256) == 3);
+        AssertAndExpect(ModPow(3,2,256) == 9);
+        AssertAndExpect(ModPow(3,3,256) == 27);
+        AssertAndExpect(ModPow(3,5,256) == 243);
+        AssertAndExpect(ModPow(3,6,256) == 217);
+    }
+
     // Various sanity tests for multiplicative inverse
     method {:test} InverseTests() {
         AssertAndExpect(Inverse(0,2) == None);


### PR DESCRIPTION
This puts in place a more efficient implememtation of exponentiation under a modulus.  The algorithm does much less work than simply calculating the exponentiation and then taking the modulus.  This is because that approach generates extremely large numbers.