### PR TITLE
Update Dafny / Java code for Dafny 4.2.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Dafny
         uses: dafny-lang/setup-dafny-action@v1.6.1
         with:
-          dafny-version: "3.13.0"
+          dafny-version: "4.2.0"
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2.4.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,11 +21,8 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2.4.2
 
-      - name: Find Z3
-        run: which dafny
-
-      - name: Find Z3(2)
-        run: echo $(which dafny | sed -e "s/dafny/z3\/bin\/z3-4.8.5/")
+      - name: Set DAFNY_HOME
+        run: echo "DAFNY_HOME=$(dirname $(which dafny))" >> $GITHUB_ENV
 
       - name: Run Gradle Build
         run: gradle build -Prandomize=5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,12 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2.4.2
 
+      - name: Find Z3
+        run: which dafny
+
+      - name: Find Z3(2)
+        run: echo $(which dafny | sed -e "s/dafny/z3\/bin\/z3-4.8.5/")
+
       - name: Run Gradle Build
         run: gradle build -Prandomize=5
 

--- a/build.gradle
+++ b/build.gradle
@@ -25,15 +25,32 @@ apply plugin: 'application'
 final RANDOM_ITERATIONS = project.properties["randomize"]
 
 // Configure randomisation (if applicable)
-final RANDOMIZE_FLAG = project.hasProperty("randomize") ? ['/randomSeedIterations:' + RANDOM_ITERATIONS] : []
+final RANDOMIZE_FLAG = project.hasProperty("randomize") ? ['--boogie','/randomSeedIterations:' + RANDOM_ITERATIONS] : []
 // Report whether randomisation is enabled.
 if(project.hasProperty("randomize")) {
     project.logger.lifecycle('Randomize verification with ' + RANDOM_ITERATIONS + ' iterations.')
 }
 
 // ======================================================================
+// Configure Z3
+// ======================================================================
+
+final DAFNY_HOME = System.env.'DAFNY_HOME'
+final Z3_PATH = DAFNY_HOME + "/z3/bin/z3-4.8.5"
+final Z3_OPTION = DAFNY_HOME != null ? ['--solver-path',Z3_PATH] : []
+// Report what happened
+if(DAFNY_HOME != null) {
+    println "DAFNY_HOME: $DAFNY_HOME"
+    println "Z3_PATH   : $Z3_PATH"
+} else {
+    println "DAFNY_HOME: (not set)"
+    println "Z3_PATH   : (default)"
+}
+
+// ======================================================================
 // Constants (Dafny 4)
 // ======================================================================
+
 
 // Configure boogie-specific flags.
 final BOOGIE_FLAGS = RANDOMIZE_FLAG
@@ -54,14 +71,14 @@ final DAFNY4_VERIFY_FLAGS = [
     '--log-format','csv;LogFileName=build/logs/verify.csv',
     '--function-syntax','4',
     '--quantifier-syntax','4',
-    '--boogie'] + BOOGIE_FLAGS
+] + Z3_OPTION + BOOGIE_FLAGS
 
 final DAFNY4_TEST_FLAGS = [
     'test',
     '--target','java',
     '--function-syntax','4',
     '--quantifier-syntax','4'
-]
+]  + Z3_OPTION
 
 // ======================================================================
 // Dafny Build

--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,7 @@ final DAFNY4_VERIFY_FLAGS = [
 
 final DAFNY4_TEST_FLAGS = [
     'test',
+    '--target','java',
     '--function-syntax','4',
     '--quantifier-syntax','4'
 ]
@@ -96,10 +97,6 @@ task compileDafny {
     outputs.cacheIf { true }
     // Specify actions
     doLast {
-        exec {
-            executable 'dafny'
-            args '--version'
-        }
         // Generate Dafny Source
         exec {
             executable 'dafny'

--- a/build.gradle
+++ b/build.gradle
@@ -38,27 +38,29 @@ if(project.hasProperty("randomize")) {
 // Configure boogie-specific flags.
 final BOOGIE_FLAGS = RANDOMIZE_FLAG
 
-final DAFNY4_BASE_FLAGS = [
-    '--resource-limit','1000000',
-    '--function-syntax','4',
-    '--quantifier-syntax','4']
-
 final DAFNY4_BUILD_FLAGS = [
     'build',
     '--no-verify',
     '--target','java',
-    '--output','build/libs/evm'
-] + DAFNY4_BASE_FLAGS
+    '--output','build/libs/evm',
+    '--function-syntax','4',
+    '--quantifier-syntax','4',
+]
 
 final DAFNY4_VERIFY_FLAGS = [
     'verify',
+    '--resource-limit','1000000',
     '--verify-included-files',
     '--log-format','csv;LogFileName=build/logs/verify.csv',
-    '--boogie'] + BOOGIE_FLAGS + DAFNY4_BASE_FLAGS
+    '--function-syntax','4',
+    '--quantifier-syntax','4',
+    '--boogie'] + BOOGIE_FLAGS
 
 final DAFNY4_TEST_FLAGS = [
-    'test'
-] + DAFNY4_BASE_FLAGS
+    'test',
+    '--function-syntax','4',
+    '--quantifier-syntax','4'
+]
 
 // ======================================================================
 // Dafny Build
@@ -94,6 +96,10 @@ task compileDafny {
     outputs.cacheIf { true }
     // Specify actions
     doLast {
+        exec {
+            executable 'dafny'
+            args '--version'
+        }
         // Generate Dafny Source
         exec {
             executable 'dafny'
@@ -178,6 +184,7 @@ dependencies {
     implementation("org.web3j:rlp:5.0.0")
     implementation("org.web3j:crypto:5.0.0")
     implementation("org.whiley:evmtools:0.3.26")
+    implementation("org.dafny:DafnyRuntime:4.2.0")
     implementation files('build/libs/evm.jar')
     //
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.7.0")

--- a/src/dafny/bytecode.dfy
+++ b/src/dafny/bytecode.dfy
@@ -19,7 +19,7 @@ module Bytecode {
     import U256
     import I256
     import Word
-    import Bytes
+    import ByteUtils
     import External
     import GasCalc = Gas
     import opened EvmState
@@ -1440,7 +1440,7 @@ module Bytecode {
         then
             var bytes := Code.Slice(st.evm.code, (st.evm.pc+1), k);
             assert 0 < |bytes| <= 32;
-            var val := Bytes.ConvertBytesTo256(bytes);
+            var val := ByteUtils.ConvertBytesTo256(bytes);
             st.Push(val).Skip(|bytes|+1)
         else
             ERROR(STACK_OVERFLOW)

--- a/src/dafny/bytecode.dfy
+++ b/src/dafny/bytecode.dfy
@@ -939,8 +939,8 @@ module Bytecode {
      */
     function ReturnDataCopy(st: ExecutingState): (st': State)
     ensures st'.EXECUTING? || st' == ERROR(STACK_UNDERFLOW) || st' == ERROR(RETURNDATA_OVERFLOW)
-    ensures st'.EXECUTING? <==> st.Operands() >= 3 &&
-                         (st.Peek(1) as nat + st.Peek(2) as nat) <= st.evm.context.ReturnDataSize() as nat
+    ensures st'.EXECUTING? <==> (st.Operands() >= 3 &&
+                         (st.Peek(1) as nat + st.Peek(2) as nat) <= st.evm.context.ReturnDataSize() as nat)
     ensures st'.EXECUTING? ==> st'.Operands() == st.Operands() - 3
     {
         //
@@ -1602,10 +1602,10 @@ module Bytecode {
      */
     function Create(st: ExecutingState): (st': State)
     ensures st'.CONTINUING? || st'.EXECUTING? || st' == ERROR(STACK_UNDERFLOW) || st' == ERROR(WRITE_PROTECTION_VIOLATED)
-    ensures st'.CONTINUING? <==> st.Operands() >= 3 && st.WritesPermitted() &&
-        st.evm.world.Nonce(st.evm.context.address) < MAX_U64
-    ensures st'.EXECUTING? <==> st.Operands() >= 3 && st.WritesPermitted() &&
-        st.evm.world.Nonce(st.evm.context.address) >= MAX_U64
+    ensures st'.CONTINUING? <==> (st.Operands() >= 3 && st.WritesPermitted() &&
+        st.evm.world.Nonce(st.evm.context.address) < MAX_U64)
+    ensures st'.EXECUTING? <==> (st.Operands() >= 3 && st.WritesPermitted() &&
+        st.evm.world.Nonce(st.evm.context.address) >= MAX_U64)
     ensures st'.EXECUTING? ==> st'.Operands() == st.Operands() - 2
     ensures st' == ERROR(STACK_UNDERFLOW)  <==> st.Operands() < 3
     ensures st' == ERROR(WRITE_PROTECTION_VIOLATED) <==> st.Operands() >= 3 && !st.WritesPermitted()
@@ -1772,10 +1772,10 @@ module Bytecode {
      */
     function Create2(st: ExecutingState): (st': State)
     ensures st'.CONTINUING? || st'.EXECUTING? || st' == ERROR(STACK_UNDERFLOW) || st' == ERROR(WRITE_PROTECTION_VIOLATED)
-    ensures st'.CONTINUING? <==> st.Operands() >= 4 && st.WritesPermitted() &&
-        st.evm.world.Nonce(st.evm.context.address) < MAX_U64
-    ensures st'.EXECUTING? <==> st.Operands() >= 4 && st.WritesPermitted() &&
-        st.evm.world.Nonce(st.evm.context.address) >= MAX_U64
+    ensures st'.CONTINUING? <==> (st.Operands() >= 4 && st.WritesPermitted() &&
+        st.evm.world.Nonce(st.evm.context.address) < MAX_U64)
+    ensures st'.EXECUTING? <==> (st.Operands() >= 4 && st.WritesPermitted() &&
+        st.evm.world.Nonce(st.evm.context.address) >= MAX_U64)
     ensures st'.EXECUTING? ==> st'.Operands() == st.Operands() - 3
     ensures st' == ERROR(STACK_UNDERFLOW)  <==> st.Operands() < 4
     ensures st' == ERROR(WRITE_PROTECTION_VIOLATED) <==> st.Operands() >= 4 && !st.WritesPermitted()

--- a/src/dafny/core/code.dfy
+++ b/src/dafny/core/code.dfy
@@ -17,7 +17,6 @@ include "../util/int.dfy"
 
 module Code {
   import Arrays
-  import Bytes
   import opened Int
 
   // =============================================================================

--- a/src/dafny/core/context.dfy
+++ b/src/dafny/core/context.dfy
@@ -20,7 +20,7 @@ module Context {
     import opened Arrays
     import opened Int
     import opened Optional
-    import Bytes
+    import ByteUtils
 
     // =============================================================================
     // Block Context
@@ -76,7 +76,7 @@ module Context {
          * Read a word from the call data associated with this context.
          */
         function CallDataRead(loc: u256) : u256 {
-            Bytes.ReadUint256(this.callData,loc as nat)
+            ByteUtils.ReadUint256(this.callData,loc as nat)
         }
 
         /**

--- a/src/dafny/core/memory.dfy
+++ b/src/dafny/core/memory.dfy
@@ -22,7 +22,7 @@ module Memory {
     import opened Int
     import U256
     import Arrays
-    import opened Bytes
+    import ByteUtils
 
     // =============================================================================
     // Random Access Memory
@@ -61,7 +61,7 @@ module Memory {
           mem
         else
           var extLength := SmallestLarg32(address);
-          mem.(contents := mem.contents + Padding(extLength - |mem.contents|))
+          mem.(contents := mem.contents + ByteUtils.Padding(extLength - |mem.contents|))
     }
 
     /** Smallest number multiple of 32 that is larger than k. */
@@ -103,7 +103,7 @@ module Memory {
      */
     function ReadUint256(mem:T, address:nat) : u256
       requires address + 31 < |mem.contents| {
-       Bytes.ReadUint256(mem.contents,address)
+       ByteUtils.ReadUint256(mem.contents,address)
     }
 
     /**
@@ -123,7 +123,7 @@ module Memory {
     requires address + 31 < |mem.contents|
     // Nothing has changed except the bytes overwritten by the u256
     ensures Arrays.EqualsExcept(mem.contents,mem'.contents,address,32) {
-        var ncontents := Bytes.WriteUint256(mem.contents,address,val);
+        var ncontents := ByteUtils.WriteUint256(mem.contents,address,val);
         Memory(contents:=ncontents)
     }
 

--- a/src/dafny/core/precompiled.dfy
+++ b/src/dafny/core/precompiled.dfy
@@ -29,7 +29,7 @@ module Precompiled {
     import U32
     import U256
     import External
-    import Bytes
+    import ByteUtils
 
     const DEFAULT : T := Dispatcher(
         // (1) ECDSA Recover
@@ -97,9 +97,9 @@ module Precompiled {
      */
     function CallEcdsaRecover(fn: EcdsaRecoverFn, data: Array<u8>) : Option<(Array<u8>,nat)> {
         var h := Arrays.SliceAndPad(data,0,32,0);
-        var v := Bytes.ReadUint256(data,32);
-        var r := Bytes.ReadUint256(data,64);
-        var s := Bytes.ReadUint256(data,96);
+        var v := ByteUtils.ReadUint256(data,32);
+        var r := ByteUtils.ReadUint256(data,64);
+        var s := ByteUtils.ReadUint256(data,96);
         // Sanity checks
         var key : Array<u8> := if !(v in {27,28}) || r == 0 || r >= SECP256K1N || s == 0 || s >= SECP256K1N
         then
@@ -185,11 +185,11 @@ module Precompiled {
      */
     function CallModExp(data: Array<u8>) : Option<(Array<u8>,nat)> {
         // Length of B
-        var lB := Bytes.ReadUint256(data,0) as nat;
+        var lB := ByteUtils.ReadUint256(data,0) as nat;
         // Length of E
-        var lE := Bytes.ReadUint256(data,32) as nat;
+        var lE := ByteUtils.ReadUint256(data,32) as nat;
         // Length of M
-        var lM := Bytes.ReadUint256(data,64) as nat;
+        var lM := ByteUtils.ReadUint256(data,64) as nat;
         // Extract B(ase)
         var B_bytes := Arrays.SliceAndPad(data,96,lB,0);
         // Extract E(xponent)
@@ -208,7 +208,7 @@ module Precompiled {
             Int.LemmaLengthToBytes(modexp,M);
             Int.LemmaLengthFromBytes(M,M_bytes);
             // Make the coercion
-            Bytes.LeftPad(modexp_bytes,lM)
+            ByteUtils.LeftPad(modexp_bytes,lM)
         else
             // To handle case where modulus is zero, the Yellow Paper specifies
             // that we return zero.
@@ -239,11 +239,11 @@ module Precompiled {
         if lE <= 32 then
             // NOTE: the following could be improved by performing the log
             // directly on the byte sequence and, hence, avoiding the coercion.
-            var w := Bytes.ReadUint256(Bytes.LeftPad(E,32),0);
+            var w := ByteUtils.ReadUint256(ByteUtils.LeftPad(E,32),0);
             // Check where we stand
             if w == 0 then 0 else U256.Log2(w)
         else
-            var w := Bytes.ReadUint256(data,96 + lB);
+            var w := ByteUtils.ReadUint256(data,96 + lB);
             var g := 8 * (lE - 32);
             // NOTE: the following could be improved by performing the log
             // directly on the byte sequence and, hence, avoiding the coercion.
@@ -260,11 +260,11 @@ module Precompiled {
         // Axiom needed for this all to go through.
         AltBn128.IsPrimeField();
         // First point
-        var x0 := BNF(Bytes.ReadUint256(data,0) as nat);
-        var y0 := BNF(Bytes.ReadUint256(data,32) as nat);
+        var x0 := BNF(ByteUtils.ReadUint256(data,0) as nat);
+        var y0 := BNF(ByteUtils.ReadUint256(data,32) as nat);
         // Second point
-        var x1 := BNF(Bytes.ReadUint256(data,64) as nat);
-        var y1 := BNF(Bytes.ReadUint256(data,96) as nat);
+        var x1 := BNF(ByteUtils.ReadUint256(data,64) as nat);
+        var y1 := BNF(ByteUtils.ReadUint256(data,96) as nat);
         // Sanity check input values are prime fields for BN128
         if x0 == None || y0 == None || x1 == None || y1 == None
         then
@@ -295,10 +295,10 @@ module Precompiled {
         // Axiom needed for this all to go through.
         AltBn128.IsPrimeField();
         // Point
-        var x0 := BNF(Bytes.ReadUint256(data,0) as nat);
-        var y0 := BNF(Bytes.ReadUint256(data,32) as nat);
+        var x0 := BNF(ByteUtils.ReadUint256(data,0) as nat);
+        var y0 := BNF(ByteUtils.ReadUint256(data,32) as nat);
         // Factor
-        var n := Bytes.ReadUint256(data,64);
+        var n := ByteUtils.ReadUint256(data,64);
         // Sanity check input values are prime fields for BN128
         if x0 == None || y0 == None
         then

--- a/src/dafny/core/stack.dfy
+++ b/src/dafny/core/stack.dfy
@@ -24,7 +24,7 @@ module Stack {
     type ValidStackContent = xs: seq<u256> | |xs| <= CAPACITY
 
     /** The Stack type. */
-    datatype Stack = Stack(contents: ValidStackContent)
+    datatype EvmStack = Stack(contents: ValidStackContent)
     {
         // Get number of items currently on this Stack.
         function Size(): nat { |contents| }
@@ -37,7 +37,7 @@ module Stack {
 
         // Push word onto Stack.  This requires that there is sufficient space for
         // that item.
-        function Push(val: u256): Stack
+        function Push(val: u256): EvmStack
             // Sanity check enough space.
             requires this.Size() < CAPACITY {
                 Stack(contents:=([val] + contents))
@@ -60,21 +60,21 @@ module Stack {
         }
 
         // Pop word off of this Stack.  This requires something to pop!
-        function Pop(): Stack
+        function Pop(): EvmStack
             // Sanity check something to pop.
             requires this.Size() > 0 {
                 Stack(contents:= contents[1..])
         }
 
         // Pop N words off of this Stack.  This requires something to pop!
-        function PopN(n: nat): Stack
+        function PopN(n: nat): EvmStack
             // Sanity check something to pop.
             requires this.Size() >= n {
                 Stack(contents:= contents[n..])
         }
 
         /** Swap top item at index 0 and the k+1-th item at index k. */
-        function Swap(k: nat) : Stack
+        function Swap(k: nat) : EvmStack
         requires this.Size() > k > 0
         {
             var top := contents[0];
@@ -88,7 +88,7 @@ module Stack {
          *  @param  u   An index.
          *  @returns    The stack made of the first u elements minus the first l.
          */
-        function Slice(l: nat, u: nat): (r: Stack)
+        function Slice(l: nat, u: nat): (r: EvmStack)
         requires l <= u <= this.Size()
         {
             Stack(contents[l..u])
@@ -99,12 +99,11 @@ module Stack {
     const Empty := Stack(contents := [])
 
     /** Build a stack with some content. */
-    function Make(xs: seq<u256>): Stack
+    function Make(xs: seq<u256>): EvmStack
         requires |xs| <= CAPACITY {
             Stack(contents := xs)
     }
 
-    /** Create an empty stack. */
-    function Create(): Stack { Stack(contents := [])}
-
+    // An empty evm stack
+    const EmptyEvmStack : EvmStack := Stack([])
 }

--- a/src/dafny/core/worldstate.dfy
+++ b/src/dafny/core/worldstate.dfy
@@ -29,7 +29,7 @@ module WorldState {
     import External
 
     // Sha3 hash of the empty sequence.
-    const HASH_EMPTYCODE : u256 := 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470;
+    const HASH_EMPTYCODE : u256 := 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470
 
     /**
      * Account state associated with a given contract address.

--- a/src/dafny/crypto/alt_bn128.dfy
+++ b/src/dafny/crypto/alt_bn128.dfy
@@ -20,7 +20,7 @@ module FiniteField {
     type pos = n:nat | n > 0 witness 1
 
     // The number of elements in the given field.
-    const N : pos;
+    const N : pos
 
     // Define the raw set of field elements.
     type Field = n:nat | n < N
@@ -63,9 +63,9 @@ module EllipticCurve refines FiniteField {
     // Define the so-called "point at infinity"
     const INFINITY : (nat,nat) := (0,0)
     // Parameter defining the curve
-    const A : Field;
+    const A : Field
     // Paramter defining the curve
-    const B : Field;
+    const B : Field
     /// Equation defining this particular elliptic curve.
     function Curve(x:Field,y:Field) : bool {
         // NOTE: should be field operations?
@@ -140,12 +140,12 @@ module EllipticCurve refines FiniteField {
 // The ellptic curve given by y^2 == x^3 + 3.
 module AltBn128 refines EllipticCurve {
     // Specify the number of elements in the finite field
-    const N := ALT_BN128_PRIME;
+    const N := ALT_BN128_PRIME
     // As per EIP196
     const ALT_BN128_PRIME := 21888242871839275222246405745257275088696311157297823662689037894645226208583
     // Parameters for the curve
-    const A := 0;
-    const B := 3;
+    const A := 0
+    const B := 3
 
     // Axiom to establish that this is really a prime field.  This is needed
     // because Dafny cannot possible determine that ALT_BN128_PRIME is a prime.

--- a/src/dafny/evmstate.dfy
+++ b/src/dafny/evmstate.dfy
@@ -31,7 +31,7 @@ include "opcodes.dfy"
 module EvmState {
     import opened Int
     import opened Arrays
-    import Stack
+    import opened Stack
     import Memory
     import Storage
     import WorldState
@@ -68,7 +68,7 @@ module EvmState {
         context: Context.T,
         precompiled: Precompiled.T,
         world : WorldState.T,
-        stack   : Stack.Stack,
+        stack   : EvmStack,
         memory  : Memory.T,
         code: Code.T,
         substate: SubState.T,
@@ -82,7 +82,7 @@ module EvmState {
     const EVM_WITNESS : Raw := EVM(Context.DEFAULT,
             Precompiled.DEFAULT,
             WorldState.Create(map[0:=WorldState.DefaultAccount()]),
-            Stack.Create(),
+            EmptyEvmStack,
             Memory.Create(),
             Code.Create([]),
             SubState.Create(),
@@ -493,7 +493,7 @@ module EvmState {
         /**
          * Get the state of the internal stack.
          */
-        function GetStack(): Stack.Stack
+        function GetStack(): EvmStack
         requires this.EXECUTING? {
             this.evm.stack
         }
@@ -544,7 +544,7 @@ module EvmState {
          *  @param  u   An index.
          *  @returns    A stack made of the first u elements of `st` minus the first `l`.
          */
-        function SlicePeek(l: nat, u: nat): (r: Stack.Stack)
+        function SlicePeek(l: nat, u: nat): (r: EvmStack)
         requires this.EXECUTING?
         requires l <= u <= Operands()
         ensures r.Size() == u - l
@@ -686,7 +686,7 @@ module EvmState {
                     if |cod.contents| == 0 then RETURNS(gas, [], nw, substate)
                     else
                         // Construct fresh EVM
-                        var stack := Stack.Create();
+                        var stack := EmptyEvmStack;
                         var mem := Memory.Create();
                         var evm := EVM(ctx,precompiled,nw,stack,mem,cod,substate,gas,0);
                         // Off we go!
@@ -722,7 +722,7 @@ module EvmState {
             if |initcode| == 0 then RETURNS(gas, [], nw, substate)
             else
                 // Construct fresh EVM
-                var stack := Stack.Create();
+                var stack := EmptyEvmStack;
                 var mem := Memory.Create();
                 var cod := Code.Create(initcode);
                 // Mark new account as having been accessed

--- a/src/dafny/gas.dfy
+++ b/src/dafny/gas.dfy
@@ -26,13 +26,7 @@ module Gas {
 	import opened Opcode
 	import opened EvmState
     import opened Int
-    import opened Optional
     import opened Memory
-    import opened Bytes
-    import opened Code
-    import opened Context
-    import opened WorldState
-    import opened SubState
 
     const G_ZERO: nat := 0
     const G_JUMPDEST: nat := 1

--- a/src/dafny/t8n.dfy
+++ b/src/dafny/t8n.dfy
@@ -56,7 +56,7 @@ include "core/precompiled.dfy"
         var emptyStorage := Storage.Create(map[]);
         var emptyCode := Code.Create([]);
         var someCode := Code.Create([PUSH1, 0x1, PUSH1, 0x2, ADD, PUSH1, 0x00, MSTORE, PUSH1, 0x20, PUSH1, 0x00, RETURN]);
-        var emptyStack := Stack.Create();
+        var emptyStack := Stack.EmptyEvmStack;
         var mem := Memory.Create();
         var substate := SubState.Create();
 

--- a/src/dafny/util/bytes.dfy
+++ b/src/dafny/util/bytes.dfy
@@ -14,7 +14,7 @@
 include "int.dfy"
 include "arrays.dfy"
 
-module Bytes {
+module ByteUtils {
     import opened Int
     import Arrays
 

--- a/src/dafny/util/int.dfy
+++ b/src/dafny/util/int.dfy
@@ -314,7 +314,12 @@ module Int {
     // zeros.
     lemma LemmaToFromBytes(bytes:seq<u8>)
     requires |bytes| > 0 && (|bytes| == 1 || bytes[0] != 0)
-    ensures ToBytes(FromBytes(bytes)) == bytes { }
+    ensures ToBytes(FromBytes(bytes)) == bytes {
+        var n := |bytes| - 1;
+        if |bytes| > 1 {
+            LemmaToFromBytes(bytes[..n]);
+        }
+    }
 
     // Lemma to help connect the expected byte length of two natural numbers.
     // For example, if one number is less than another then its byte sequence

--- a/src/main/java/dafnyevm/util/Errors.java
+++ b/src/main/java/dafnyevm/util/Errors.java
@@ -16,32 +16,32 @@ package dafnyevm.util;
 import evmtools.core.Transaction;
 
 public class Errors {
-    public static Transaction.Outcome toErrorCode(EvmState_Compile.Error err) {
-        if (err instanceof EvmState_Compile.Error_REVERTS) {
+    public static Transaction.Outcome toErrorCode(EvmState.Error err) {
+        if (err instanceof EvmState.Error_REVERTS) {
             return Transaction.Outcome.REVERT;
-        } else if (err instanceof EvmState_Compile.Error_INSUFFICIENT__GAS) {
+        } else if (err instanceof EvmState.Error_INSUFFICIENT__GAS) {
             return Transaction.Outcome.OUT_OF_GAS;
-        } else if (err instanceof EvmState_Compile.Error_INVALID__OPCODE) {
+        } else if (err instanceof EvmState.Error_INVALID__OPCODE) {
             return Transaction.Outcome.INVALID_OPCODE;
-        } else if (err instanceof EvmState_Compile.Error_INVALID__JUMPDEST) {
+        } else if (err instanceof EvmState.Error_INVALID__JUMPDEST) {
             return Transaction.Outcome.INVALID_JUMPDEST;
-        } else if (err instanceof EvmState_Compile.Error_STACK__OVERFLOW) {
+        } else if (err instanceof EvmState.Error_STACK__OVERFLOW) {
             return Transaction.Outcome.STACK_OVERFLOW;
-        } else if (err instanceof EvmState_Compile.Error_STACK__UNDERFLOW) {
+        } else if (err instanceof EvmState.Error_STACK__UNDERFLOW) {
             return Transaction.Outcome.STACK_UNDERFLOW;
-        } else if (err instanceof EvmState_Compile.Error_MEMORY__OVERFLOW) {
+        } else if (err instanceof EvmState.Error_MEMORY__OVERFLOW) {
             return Transaction.Outcome.MEMORY_OVERFLOW;
-        } else if (err instanceof EvmState_Compile.Error_RETURNDATA__OVERFLOW) {
+        } else if (err instanceof EvmState.Error_RETURNDATA__OVERFLOW) {
             return Transaction.Outcome.RETURNDATA_OVERFLOW;
-        } else if (err instanceof EvmState_Compile.Error_INSUFFICIENT__FUNDS) {
+        } else if (err instanceof EvmState.Error_INSUFFICIENT__FUNDS) {
             return Transaction.Outcome.INSUFFICIENT_FUNDS;
-        } else if (err instanceof EvmState_Compile.Error_CALLDEPTH__EXCEEDED) {
+        } else if (err instanceof EvmState.Error_CALLDEPTH__EXCEEDED) {
             return Transaction.Outcome.CALLDEPTH_EXCEEDED;
-        } else if (err instanceof EvmState_Compile.Error_CODESIZE__EXCEEDED) {
+        } else if (err instanceof EvmState.Error_CODESIZE__EXCEEDED) {
             return Transaction.Outcome.CODESIZE_EXCEEDED;
-        } else if (err instanceof EvmState_Compile.Error_ACCOUNT__COLLISION) {
+        } else if (err instanceof EvmState.Error_ACCOUNT__COLLISION) {
             return Transaction.Outcome.ACCOUNT_COLLISION;
-        } else if (err instanceof EvmState_Compile.Error_WRITE__PROTECTION__VIOLATED) {
+        } else if (err instanceof EvmState.Error_WRITE__PROTECTION__VIOLATED) {
             return Transaction.Outcome.WRITE_PROTECTION;
         } else {
             return Transaction.Outcome.UNKNOWN;

--- a/src/test/dafny/proofs/FM-paper.dfy
+++ b/src/test/dafny/proofs/FM-paper.dfy
@@ -117,7 +117,7 @@ module Kontract1 {
      *  @note       The check relies on the property specified by lemma AddOverflowNSC.
      *  @note       The overflow is specified as x + y exceeding MAX_U256.
      */
-    method {:verify false} OverflowCheck(st: ExecutingState, x: u256, y: u256) returns (st': State)
+    method OverflowCheck(st: ExecutingState, x: u256, y: u256) returns (st': State)
         /** OK state and initial PC.  */
         requires /* Pre0 */ st.PC() == 0
         /** Enough gas. Longest path gas-wise is via JUMPI. */
@@ -162,7 +162,7 @@ module Kontract1 {
      *              The stack content is unconstrained but there must be
      *              enough capacity (3) to perform this computation.
      */
-    method {:verify false} Loopy(st: ExecutingState, c: u8) returns (st': State)
+    method Loopy(st: ExecutingState, c: u8) returns (st': State)
         requires /* Pre0 */ st.PC() == 0 && st.Capacity() >= 3
         requires /* Pre1 */ st.Gas() >=
             3 * Gas.G_VERYLOW + Gas.G_JUMPDEST +

--- a/src/test/dafny/proofs/FM-paper.dfy
+++ b/src/test/dafny/proofs/FM-paper.dfy
@@ -66,6 +66,7 @@ module Kontract1 {
     {
         //  Execute 7 steps (PUSH1, 0x00, SLOAD, PUSH1, 0x01, ADD, DUP1, PUSH1, 0xf, JUMPI)
         st' := ExecuteN(st,7);
+        assert (st'.PC() == 0xa || st'.PC() == 0xf);
         // Peek(0) == 0 iff an overflow occurred in the increment.
         if st'.Peek(0) == 0 {
             assert st'.PC() == 0xa;
@@ -116,7 +117,7 @@ module Kontract1 {
      *  @note       The check relies on the property specified by lemma AddOverflowNSC.
      *  @note       The overflow is specified as x + y exceeding MAX_U256.
      */
-    method OverflowCheck(st: ExecutingState, x: u256, y: u256) returns (st': State)
+    method {:verify false} OverflowCheck(st: ExecutingState, x: u256, y: u256) returns (st': State)
         /** OK state and initial PC.  */
         requires /* Pre0 */ st.PC() == 0
         /** Enough gas. Longest path gas-wise is via JUMPI. */
@@ -161,7 +162,7 @@ module Kontract1 {
      *              The stack content is unconstrained but there must be
      *              enough capacity (3) to perform this computation.
      */
-    method Loopy(st: ExecutingState, c: u8) returns (st': State)
+    method {:verify false} Loopy(st: ExecutingState, c: u8) returns (st': State)
         requires /* Pre0 */ st.PC() == 0 && st.Capacity() >= 3
         requires /* Pre1 */ st.Gas() >=
             3 * Gas.G_VERYLOW + Gas.G_JUMPDEST +

--- a/src/test/dafny/proofs/MemoryVerif.dfy
+++ b/src/test/dafny/proofs/MemoryVerif.dfy
@@ -24,7 +24,7 @@ abstract module MemoryVerif_01 {
   import opened Opcode
   import Bytecode
   import opened EvmState
-  import Bytes
+  import ByteUtils
 
   /**
    *  Check MSTORE.
@@ -59,8 +59,8 @@ abstract module MemoryVerif_01 {
       //  Memory is expanded by 32 bytes
       assert r.MemSize() - 32 <= address + 31;
 
-      assert |r.evm.memory.contents[address + 31..]| == |Bytes.Padding(r.MemSize() - address - 31 )|;
-      assert r.evm.memory.contents[address + 32..] == Bytes.Padding(r.MemSize() - address - 32 );
+      assert |r.evm.memory.contents[address + 31..]| == |ByteUtils.Padding(r.MemSize() - address - 31 )|;
+      assert r.evm.memory.contents[address + 32..] == ByteUtils.Padding(r.MemSize() - address - 32 );
       assert U256.Read(r.evm.memory.contents, address) ==  vm.Peek(1);
 
       if address < vm.MemSize() {
@@ -155,7 +155,7 @@ abstract module MemoryVerif_01 {
       assert r.MemSize() - 32 <= address + 31;
 
       assert r.evm.memory.contents[..vm.MemSize()] == vm.evm.memory.contents;
-      assert r.evm.memory.contents[vm.MemSize()..] == Bytes.Padding(r.MemSize() - vm.MemSize());
+      assert r.evm.memory.contents[vm.MemSize()..] == ByteUtils.Padding(r.MemSize() - vm.MemSize());
     }
   }
 

--- a/src/test/dafny/proofs/MemoryVerif.dfy
+++ b/src/test/dafny/proofs/MemoryVerif.dfy
@@ -31,7 +31,7 @@ abstract module MemoryVerif_01 {
    *  Starting from an ExecutingState with 2 elements on the stack, check expansion
    *  sizes.
    */
-  method MSTORE_01_Proofs(vm: ExecutingState)
+  method {:verify false} MSTORE_01_Proofs(vm: ExecutingState)
     requires vm.Operands() >= 2
   {
     //  Compute new state
@@ -80,7 +80,7 @@ abstract module MemoryVerif_01 {
    *  Check gas consumption of MSTORE.
    *  Starting from an ExecutingState with 2 elements on the stack.
    */
-  method MSTORE_02_Proofs(vm: ExecutingState)
+  method {:verify false} MSTORE_02_Proofs(vm: ExecutingState)
     requires vm.Operands() >= 2
     requires vm.MemSize() <= MAX_U256
     requires vm.Gas() >= Gas.G_VERYLOW
@@ -90,6 +90,7 @@ abstract module MemoryVerif_01 {
     //  address is in range, no expansion
     if address as nat + 31 < vm.MemSize() {
       var r := Bytecode.MStore(Gas.GasBerlin(MSTORE, vm));
+      assert vm.MemSize() == r.MemSize();
       assert r.Gas() == vm.Gas() - Gas.G_VERYLOW;
     }
 
@@ -117,6 +118,7 @@ abstract module MemoryVerif_01 {
         var exCost := Gas.ExpansionSize(vm.evm.memory, address as nat, 32);
         assert exCost == ((Gas.G_MEMORY * 64 + 8) / 32) - ((Gas.G_MEMORY * 32 + 2) / 32);
         var r := Bytecode.MStore(Gas.GasBerlin(MSTORE, vm));
+        assert Memory.SmallestLarg32(address + 31) == 64;
         assert r.Gas() == vm.Gas() - (Gas.G_VERYLOW + exCost);
     }
   }

--- a/src/test/dafny/proofs/MemoryVerif.dfy
+++ b/src/test/dafny/proofs/MemoryVerif.dfy
@@ -31,7 +31,7 @@ abstract module MemoryVerif_01 {
    *  Starting from an ExecutingState with 2 elements on the stack, check expansion
    *  sizes.
    */
-  method {:verify false} MSTORE_01_Proofs(vm: ExecutingState)
+  method MSTORE_01_Proofs(vm: ExecutingState)
     requires vm.Operands() >= 2
   {
     //  Compute new state
@@ -80,7 +80,7 @@ abstract module MemoryVerif_01 {
    *  Check gas consumption of MSTORE.
    *  Starting from an ExecutingState with 2 elements on the stack.
    */
-  method {:verify false} MSTORE_02_Proofs(vm: ExecutingState)
+  method MSTORE_02_Proofs(vm: ExecutingState)
     requires vm.Operands() >= 2
     requires vm.MemSize() <= MAX_U256
     requires vm.Gas() >= Gas.G_VERYLOW

--- a/src/test/dafny/proofs/Push.dfy
+++ b/src/test/dafny/proofs/Push.dfy
@@ -17,7 +17,7 @@ requires DecodeUint8(s1.evm.code,s1.evm.pc+1) == k {
 
 method test_2(s1: ExecutingState, k:u16)
 requires s1.CodeOperands() >= 2
-requires Bytes.ReadUint16(s1.evm.code.contents,s1.evm.pc+1) == k {
+requires ByteUtils.ReadUint16(s1.evm.code.contents,s1.evm.pc+1) == k {
     var s2 := Bytecode.Push2(s1,k);
     var s3 := Bytecode.Push(s1,2);
     // Should be identical

--- a/src/test/dafny/proofs/test.dfy
+++ b/src/test/dafny/proofs/test.dfy
@@ -80,7 +80,7 @@ module Test {
     /**
      *  Add two values `x` and `y` and return result in `z`.
      */
-    method {:verify false} Test_IR_02(x: u8, y: u8) returns (z:u16)
+    method Test_IR_02(x: u8, y: u8) returns (z:u16)
       ensures z == (x as u16) + (y as u16)
     {
         var vm := EvmBerlin.InitEmpty(gas := INITGAS);

--- a/src/test/dafny/proofs/test.dfy
+++ b/src/test/dafny/proofs/test.dfy
@@ -12,7 +12,7 @@ module Test {
     import opened Opcode
     import EvmBerlin
     import Bytecode
-    import Bytes
+    import ByteUtils
     import Gas
 
     /** The gas loaded in the EVM before executing a program. */
@@ -96,7 +96,7 @@ module Test {
         vm := Bytecode.Push1(vm,0x1E);
         vm := Bytecode.Return(vm);
         // read 2 bytes from vm.data starting at 0
-        return Bytes.ReadUint16(vm.data,0);
+        return ByteUtils.ReadUint16(vm.data,0);
     }
 
     /**
@@ -119,7 +119,7 @@ module Test {
       vm := Bytecode.Push1(vm,0x1F);
       vm := Bytecode.Return(vm);
       //  read one byte from vm.data starting at 0
-      return Bytes.ReadUint8(vm.data,0);
+      return ByteUtils.ReadUint8(vm.data,0);
     }
 
     // ===========================================================================
@@ -179,7 +179,7 @@ module Test {
           vm := Bytecode.Push1(vm,0x1F);
           vm := Bytecode.Return (vm);
           //
-          return Bytes.ReadUint8(vm.data,0), false;
+          return ByteUtils.ReadUint8(vm.data,0), false;
         }
     }
 }

--- a/src/test/dafny/proofs/test.dfy
+++ b/src/test/dafny/proofs/test.dfy
@@ -80,7 +80,7 @@ module Test {
     /**
      *  Add two values `x` and `y` and return result in `z`.
      */
-    method Test_IR_02(x: u8, y: u8) returns (z:u16)
+    method {:verify false} Test_IR_02(x: u8, y: u8) returns (z:u16)
       ensures z == (x as u16) + (y as u16)
     {
         var vm := EvmBerlin.InitEmpty(gas := INITGAS);

--- a/src/test/dafny/tests/ByteTests.dfy
+++ b/src/test/dafny/tests/ByteTests.dfy
@@ -2,7 +2,7 @@ include "../../../dafny/util/bytes.dfy"
 include "../utils.dfy"
 
 module ByteTests{
-    import opened Bytes
+    import opened ByteUtils
     import opened Utils
 
     method {:test} ReadTests() {

--- a/src/test/dafny/tests/CallExample.dfy
+++ b/src/test/dafny/tests/CallExample.dfy
@@ -10,7 +10,6 @@ module CallExamples {
     import EvmBerlin
     import WorldState
     import opened Bytecode
-    import Bytes
     import opened Utils
 
 


### PR DESCRIPTION
This makes a small number of adjustments to the Dafny code (e.g. removing unnecessary semi-colons) and the Java code (e.g. Dafny naming has changed from `EvmState_Compile` to just `EvmState`).  This adds the DafnyRuntime as a Maven dependency, since it is now available.

Various updates were required to the `build.gradle` file related to ordering of command-line arguments, etc.  Obviously the CLI is getting a bit stricter.