### PR TITLE
Support `-Psolver-path=` #592

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,17 +35,22 @@ if(project.hasProperty("randomize")) {
 // Configure Z3
 // ======================================================================
 
-final DAFNY_HOME = System.env.'DAFNY_HOME'
-final Z3_PATH = DAFNY_HOME + "/z3/bin/z3-4.8.5"
-final Z3_OPTION = DAFNY_HOME != null ? ['--solver-path',Z3_PATH] : []
-// Report what happened
-if(DAFNY_HOME != null) {
-    println "DAFNY_HOME: $DAFNY_HOME"
-    println "Z3_PATH   : $Z3_PATH"
-} else {
-    println "DAFNY_HOME: (not set)"
-    println "Z3_PATH   : (default)"
+def DAFNY_HOME = System.env.'DAFNY_HOME'
+// Configure Z3_PATH based on DAFNY_HOME
+def Z3_PATH = DAFNY_HOME != null ? DAFNY_HOME + "/z3/bin/z3-4.8.5" : null
+
+if(project.hasProperty("solver-path")) {
+  Z3_PATH = project.properties["solver-path"]				       
 }
+
+// Configure option for use with dafny command
+final Z3_OPTION = DAFNY_HOME != null ? ['--solver-path',Z3_PATH] : []
+
+// Report what happened
+def DAFNY_HOME_STR = DAFNY_HOME != null ? DAFNY_HOME : "(unset)"
+def Z3_PATH_STR = Z3_PATH != null ? Z3_PATH : "(unset)"
+println "DAFNY_HOME: $DAFNY_HOME_STR"
+println "Z3_PATH   : $Z3_PATH_STR"
 
 // ======================================================================
 // Constants (Dafny 4)


### PR DESCRIPTION
This adds support for overriding the default version of Z3 used for building the project.  That can be useful, for example, when trying out new versions of Z3 to see whether they make life better or worse.