### PR TITLE
Fixes for Dafny `4.4.0` and Z3 `4.8.5`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,9 +16,9 @@ jobs:
           submodules: recursive
 
       - name: Install Dafny
-        uses: dafny-lang/setup-dafny-action@v1.6.1
+        uses: dafny-lang/setup-dafny-action@v1.7.0
         with:
-          dafny-version: "4.2.0"
+          dafny-version: "4.4.0"
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2.4.2

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -69,7 +69,7 @@ dafny_verify_global: $(DAFNY_VERIFY_WITNESS_GLOBAL)
 $(DAFNY_VERIFY_WITNESS_GLOBAL) : $(DAFNY_SRC_FILES)
 	@echo Verifying Dafny
 #	$(SILENCER)$(DAFNY_EXEC) /vcsLoad:2 /compile:0 /rlimit:100000 /functionSyntax:4 /quantifierSyntax:4 $(DAFNY_ARGS) $(DAFNY_SRC_FILES)
-	$(SILENCER)$(DAFNY_EXEC) verify $(DAFNY_ARGS) --verify-included-files --resource-limit 100000 $(DAFNY_SRC_FILES)
+	$(SILENCER)$(DAFNY_EXEC) verify $(DAFNY_ARGS) --verify-included-files --resource-limit 1000000 $(DAFNY_SRC_FILES)
 	$(SILENCER)mkdir -p $(DAFNY_OUT_DIR)
 	$(SILENCER)touch $@
 
@@ -113,7 +113,7 @@ dafny_translate: $(DAFNY_OUT_FILENAME) # $(DAFNY_TEST_WITNESS_GLOBAL)
 
 $(DAFNY_OUT_FILENAME) : $(DAFNY_SRC_FILES)
 	@echo Translating Dafny
-	$(SILENCER)$(DAFNY_EXEC) /functionSyntax:4 /quantifierSyntax:4 /rlimit:100000 /vcsLoad:2 /compileTarget:go /compileVerbose:0 /spillTargetCode:3 /noExterns /warnShadowing /deprecation:2 $(SOLVER_OPTION) /out:$(DAFNY_OUT_ARG) $(DAFNY_SRC_ENTRY_POINT) /compile:2 #$(DAFNY_ARGS)
+	$(SILENCER)$(DAFNY_EXEC) /functionSyntax:4 /quantifierSyntax:4 /rlimit:1000000 /vcsLoad:2 /compileTarget:go /compileVerbose:0 /spillTargetCode:3 /noExterns /warnShadowing /deprecation:2 $(SOLVER_OPTION) /out:$(DAFNY_OUT_ARG) $(DAFNY_SRC_ENTRY_POINT) /compile:2 #$(DAFNY_ARGS)
 #	Dafny v4 new CLI: missing --deprecation and --noExterns
 #	$(SILENCER)$(DAFNY_EXEC) build $(DAFNY_ARGS) --no-verify --target go --warn-shadowing --test-assumptions Externs --output:$(DAFNY_OUT_ARG) $(DAFNY_SRC_ENTRY_POINT) #--deprecation 2  -noExterns
 

--- a/src/test/dafny/proofs/FM-paper.dfy
+++ b/src/test/dafny/proofs/FM-paper.dfy
@@ -66,6 +66,7 @@ module Kontract1 {
     {
         // Assumption required because Z3 cannot figure this out!
         assume {:axiom} {PUSH1,SLOAD,ADD,DUP1,JUMPI,REVERT,JUMPDEST,SSTORE,STOP} <= EvmFork.BERLIN_BYTECODES;
+        //
         //  Execute 7 steps (PUSH1, 0x00, SLOAD, PUSH1, 0x01, ADD, DUP1, PUSH1, 0xf, JUMPI)
         st' := ExecuteN(st,7);
         assert (st'.PC() == 0xa || st'.PC() == 0xf);
@@ -78,6 +79,7 @@ module Kontract1 {
             assert st'.PC() == 0xf;
             st' := ExecuteN(st',4);
             assert st'.RETURNS?;
+            assert st.Load(0) as nat < MAX_U256;
         }
     }
 

--- a/src/test/dafny/tests/ArrayTests.dfy
+++ b/src/test/dafny/tests/ArrayTests.dfy
@@ -11,6 +11,7 @@ module ArrayTests{
         // n=1
         AssertAndExpect(Copy([4],[1,2,3],0) == [4,2,3]);
         AssertAndExpect(Copy([4],[1,2,3],1) == [1,4,3]);
+        reveal Copy();
         AssertAndExpect(Copy([4],[1,2,4],2) == [1,2,4]);
         // n=2
         AssertAndExpect(Copy([4,5],[1,2,3],0) == [4,5,3]);


### PR DESCRIPTION
This puts through a small number of tweaks which allow the proofs / tests to verify under Dafny `4.4.0` and Z3 `4.8.5`.