### PR TITLE
Implement EIP5656 `MCOPY`

### DIFF
--- a/src/dafny/bytecode.dfy
+++ b/src/dafny/bytecode.dfy
@@ -1341,6 +1341,27 @@ module Bytecode {
     }
 
     /**
+     * Perform an efficient copy of memory from one area to another.
+     */
+    function MCopy(st: ExecutingState): (st': State) {
+        //
+        if st.Operands() >= 3
+        then
+            var dst := st.Peek(0) as nat;
+            var src := st.Peek(1) as nat;
+            var len := st.Peek(2) as nat;
+            //
+            // Slice bytes out of memory
+            var data := Memory.Slice(st.evm.memory,src,len);
+            // Sanity check
+            assert |data| == len;
+            // Copy slice into memory
+            st.Expand(src, len).Expand(dst, len).Pop(3).Copy(dst,data).Next()
+        else
+            ERROR(STACK_UNDERFLOW)
+    }
+
+    /**
      * Perform a static relative jump using a given offset from the position
      * immediately after this instruction.  This instruction does not read any
      * operands from the stack.

--- a/src/dafny/evm.dfy
+++ b/src/dafny/evm.dfy
@@ -177,6 +177,7 @@ module EVM {
             case MSIZE => s.UseGas(G_BASE)
             case GAS => s.UseGas(G_BASE)
             case JUMPDEST => s.UseGas(G_JUMPDEST)
+            case MCOPY => s.UseGas(CostExpandDoubleRange(s,3,0,2,1,2) + G_VERYLOW + CostCopy(s,2))
             case PUSH0 => s.UseGas(G_BASE)
             // 0x60s & 0x70s: Push operations
             case PUSH1 => s.UseGas(G_VERYLOW)
@@ -343,6 +344,7 @@ module EVM {
             case MSIZE => Bytecode.MSize(st)
             case GAS => Bytecode.Gas(st)
             case JUMPDEST => Bytecode.JumpDest(st)
+            case MCOPY => Bytecode.MCopy(st)
             case PUSH0 => Bytecode.Push0(st)
             // 0x60s & 0x70s: Push operations
             case PUSH1 => Bytecode.Push(st,1)

--- a/src/main/java/dafnyevm/DafnyEvm.java
+++ b/src/main/java/dafnyevm/DafnyEvm.java
@@ -127,7 +127,7 @@ public class DafnyEvm {
 		case "BERLIN":
 			fork = BERLIN();
 			break;
-		case "DENCUN":
+		case "CANCUN":
 			fork = CANCUN();
 			break;			
 		case "LONDON":

--- a/src/test/java/dafnyevm/GeneralStateTests.java
+++ b/src/test/java/dafnyevm/GeneralStateTests.java
@@ -150,10 +150,10 @@ public class GeneralStateTests {
             "eip1559_.*_0_0_0",
             "badOpcodes_Berlin_0_23_0", // weird?
             // Cancun
-            "MCOPY_Cancun_.*",
-            "MCOPY_copy_cost_Cancun_.*",
-            "MCOPY_memory_expansion_cost_Cancun_.*",
-            "MCOPY_memory_hash_Cancun_.*",
+//            "MCOPY_Cancun_.*",
+//            "MCOPY_copy_cost_Cancun_.*",
+//            "MCOPY_memory_expansion_cost_Cancun_.*",
+//            "MCOPY_memory_hash_Cancun_.*",
             "transStorageOK_Cancun_.*",
             "transStorageReset_Cancun_.*",
             //


### PR DESCRIPTION
This puts in place a fairly straightfoward implementation of EIP5656 for the `MCOPY` instruction.  This performs a simple memory-to-memory copy of an arbitrary length of bytes.